### PR TITLE
Add timestamps to log output

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -13,7 +13,7 @@ from fastapi.responses import FileResponse
 
 from app.routers import cats, visits, cleaning_cycles, dashboard
 
-logging.basicConfig(level=logging.INFO)
+logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s:%(name)s:%(message)s")
 logger = logging.getLogger(__name__)
 
 POLL_INTERVAL_SECONDS = int(os.getenv("POLL_INTERVAL_SECONDS", "5"))


### PR DESCRIPTION
Adds timestamps to Docker log output by including `%(asctime)s` in the logging format string.

Closes #9

Generated with [Claude Code](https://claude.ai/code)