### PR TITLE
Replace logger.error with logger.exception in except blocks

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -38,7 +38,7 @@ def run_poller():
                 dashboard_state.last_successful_poll_at = datetime.now(timezone.utc)
                 time.sleep(POLL_INTERVAL_SECONDS)
         except Exception as e:
-            logger.error(f"Poller crashed, restarting: {e}")
+            logger.exception("Poller crashed, restarting")
             time.sleep(10)
         finally:
             if db:

--- a/app/poller.py
+++ b/app/poller.py
@@ -62,7 +62,7 @@ def fetch_device_key() -> Optional[str]:
                 return key
         logger.warning("Device not found in cloud response")
     except Exception as e:
-        logger.error(f"Failed to fetch device key: {e}")
+        logger.exception("Failed to fetch device key")
     return None
 
 
@@ -116,7 +116,7 @@ class LitterboxPoller:
         try:
             data = self.device.status()
         except Exception as e:
-            logger.error(f"Failed to read device status: {e}")
+            logger.exception("Failed to read device status")
             return
 
         if not data or "dps" not in data:


### PR DESCRIPTION
Replaces `logger.error` with `logger.exception` in all except blocks so that full stack traces are preserved when logging exceptions.

One call (`poller.py:102`) was intentionally left as `logger.error` since it is not inside an except block.

Fixes #5.

Generated with [Claude Code](https://claude.ai/code)