### PR TITLE
Replace logger.error with logger.exception in except blocks

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -38,7 +38,7 @@ def run_poller():
                 dashboard_state.last_successful_poll_at = datetime.now(timezone.utc)
                 time.sleep(POLL_INTERVAL_SECONDS)
         except Exception as e:
-            logger.error(f"Poller crashed, restarting: {e}")
+            logger.exception("Poller crashed, restarting")
             time.sleep(10)
         finally:
             if db:

--- a/app/poller.py
+++ b/app/poller.py
@@ -63,7 +63,7 @@ class LitterboxPoller:
             self.cloud = make_cloud()
             logger.info("Cloud connection initialized")
         except Exception as e:
-            logger.error(f"Failed to initialize cloud connection: {e}")
+            logger.exception("Failed to initialize cloud connection")
             self.cloud = None
 
     def poll(self):
@@ -76,7 +76,7 @@ class LitterboxPoller:
         try:
             result = self.cloud.getstatus(DEVICE_ID)
         except Exception as e:
-            logger.error(f"Failed to read device status from cloud: {e}")
+            logger.exception("Failed to read device status from cloud")
             self._init_cloud()
             return
 


### PR DESCRIPTION
Replaces `logger.error` with `logger.exception` in all except blocks so that full stack traces are preserved when logging exceptions.

Fixes #5.

Generated with [Claude Code](https://claude.ai/code)