### PR TITLE
fix: add default values for required postgres env vars

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,13 @@
+# PostgreSQL configuration
+# These default to the values shown below if not set, but you should override
+# POSTGRES_PASSWORD in any non-development environment.
+POSTGRES_USER=litterbox
+POSTGRES_PASSWORD=changeme
+POSTGRES_DB=litterbox
+
+# Tuya device configuration
+TUYA_DEVICE_ID=
+TUYA_DEVICE_IP=
+TUYA_API_KEY=
+TUYA_API_SECRET=
+TUYA_API_REGION=

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,7 +4,7 @@ services:
     ports:
       - "8000:8000"
     environment:
-      - DATABASE_URL=postgresql://${POSTGRES_USER}:${POSTGRES_PASSWORD}@db:5432/${POSTGRES_DB}
+      - DATABASE_URL=postgresql://${POSTGRES_USER:-litterbox}:${POSTGRES_PASSWORD:-changeme}@db:5432/${POSTGRES_DB:-litterbox}
       - TUYA_DEVICE_ID=${TUYA_DEVICE_ID}
       - TUYA_DEVICE_IP=${TUYA_DEVICE_IP}
       - TUYA_API_KEY=${TUYA_API_KEY}
@@ -20,13 +20,13 @@ services:
   db:
     image: postgres:16-alpine
     environment:
-      - POSTGRES_USER=${POSTGRES_USER}
-      - POSTGRES_PASSWORD=${POSTGRES_PASSWORD}
-      - POSTGRES_DB=${POSTGRES_DB}
+      - POSTGRES_USER=${POSTGRES_USER:-litterbox}
+      - POSTGRES_PASSWORD=${POSTGRES_PASSWORD:-changeme}
+      - POSTGRES_DB=${POSTGRES_DB:-litterbox}
     volumes:
       - postgres_data:/var/lib/postgresql/data
     healthcheck:
-      test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER}"]
+      test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER:-litterbox}"]
       interval: 5s
       timeout: 5s
       retries: 5


### PR DESCRIPTION
Use `${VAR:-default}` syntax so DATABASE_URL and pg_isready healthcheck work when POSTGRES_USER/POSTGRES_PASSWORD/POSTGRES_DB are not explicitly set in the environment. Add .env.example to document required variables.

Closes #7

Generated with [Claude Code](https://claude.ai/code)