### PR TITLE
fix: require DATABASE_URL env var and harden database config

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,9 +1,13 @@
 # PostgreSQL configuration
-# These default to the values shown below if not set, but you should override
-# POSTGRES_PASSWORD in any non-development environment.
+# These are used by docker-compose to configure the database container.
+# Override POSTGRES_PASSWORD in any non-development environment.
 POSTGRES_USER=litterbox
 POSTGRES_PASSWORD=changeme
 POSTGRES_DB=litterbox
+
+# Full database URL (required). The app will refuse to start without this.
+# For local development without Docker:
+DATABASE_URL=postgresql://litterbox:changeme@localhost:5432/litterbox
 
 # Tuya device configuration
 TUYA_DEVICE_ID=

--- a/app/database.py
+++ b/app/database.py
@@ -1,17 +1,21 @@
 import os
+from typing import Generator
+
 from sqlalchemy import create_engine
-from sqlalchemy.orm import sessionmaker
+from sqlalchemy.orm import Session, sessionmaker
 
-DATABASE_URL = os.getenv(
-    "DATABASE_URL",
-    "postgresql://litterbox:litterbox@localhost:5432/litterbox"
-)
+DATABASE_URL = os.environ.get("DATABASE_URL")
+if not DATABASE_URL:
+    raise RuntimeError(
+        "DATABASE_URL environment variable is not set. "
+        "See .env.example for configuration."
+    )
 
-engine = create_engine(DATABASE_URL)
+engine = create_engine(DATABASE_URL, pool_pre_ping=True)
 SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
 
 
-def get_db():
+def get_db() -> Generator[Session, None, None]:
     """FastAPI dependency — yields a DB session and closes it after the request."""
     db = SessionLocal()
     try:


### PR DESCRIPTION
Removes hardcoded database credentials and hardens the SQLAlchemy engine configuration.

Changes:
- Raise `RuntimeError` at startup if `DATABASE_URL` is not set
- Add `pool_pre_ping=True` to avoid stale connections
- Add `Generator[Session, None, None]` return type to `get_db()`
- Update `.env.example` with `DATABASE_URL` entry

Closes #4

Generated with [Claude Code](https://claude.ai/code)