### PR TITLE
feat: add responsive mobile layout with slide-in sidebar

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,29 +1,29 @@
 import { useState, useEffect } from 'react'
-import { BrowserRouter, Routes, Route, NavLink, useLocation } from 'react-router-dom'
+import { BrowserRouter, Routes, Route, NavLink } from 'react-router-dom'
 import Dashboard from './pages/Dashboard'
 import Visits from './pages/Visits'
 import Cats from './pages/Cats'
 import './index.css'
 import './App.css'
 
-function Sidebar({ darkMode, onToggleDarkMode }) {
+function Sidebar({ darkMode, onToggleDarkMode, isOpen, onClose }) {
   return (
-    <aside className="sidebar">
+    <aside className={`sidebar${isOpen ? ' is-open' : ''}`}>
       <div className="sidebar-logo">
         <h1>litterbox</h1>
         <p>cat health monitor</p>
       </div>
 
       <nav className="sidebar-nav">
-        <NavLink to="/" end className={({ isActive }) => `nav-item ${isActive ? 'active' : ''}`}>
+        <NavLink to="/" end className={({ isActive }) => `nav-item ${isActive ? 'active' : ''}`} onClick={onClose}>
           <span className="nav-icon">📊</span>
           Dashboard
         </NavLink>
-        <NavLink to="/visits" className={({ isActive }) => `nav-item ${isActive ? 'active' : ''}`}>
+        <NavLink to="/visits" className={({ isActive }) => `nav-item ${isActive ? 'active' : ''}`} onClick={onClose}>
           <span className="nav-icon">📋</span>
           Visits
         </NavLink>
-        <NavLink to="/cats" className={({ isActive }) => `nav-item ${isActive ? 'active' : ''}`}>
+        <NavLink to="/cats" className={({ isActive }) => `nav-item ${isActive ? 'active' : ''}`} onClick={onClose}>
           <span className="nav-icon">🐱</span>
           Cats
         </NavLink>
@@ -46,6 +46,7 @@ function AppShell() {
   const [darkMode, setDarkMode] = useState(() => {
     return localStorage.getItem('theme') === 'dark'
   })
+  const [sidebarOpen, setSidebarOpen] = useState(false)
 
   useEffect(() => {
     document.documentElement.setAttribute('data-theme', darkMode ? 'dark' : 'light')
@@ -54,7 +55,30 @@ function AppShell() {
 
   return (
     <div className="app-shell">
-      <Sidebar darkMode={darkMode} onToggleDarkMode={() => setDarkMode(d => !d)} />
+      <header className="mobile-header">
+        <button className="hamburger-btn" onClick={() => setSidebarOpen(true)} aria-label="Open menu">
+          ☰
+        </button>
+        <span className="mobile-logo">litterbox</span>
+        <button
+          className="btn btn-secondary btn-sm"
+          onClick={() => setDarkMode(d => !d)}
+          aria-label="Toggle dark mode"
+        >
+          {darkMode ? '☀️' : '🌙'}
+        </button>
+      </header>
+
+      {sidebarOpen && (
+        <div className="sidebar-overlay" onClick={() => setSidebarOpen(false)} />
+      )}
+
+      <Sidebar
+        darkMode={darkMode}
+        onToggleDarkMode={() => setDarkMode(d => !d)}
+        isOpen={sidebarOpen}
+        onClose={() => setSidebarOpen(false)}
+      />
       <main className="main-content">
         <Routes>
           <Route path="/" element={<Dashboard />} />

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -400,3 +400,75 @@ body {
   color: var(--text-muted);
   font-size: 13px;
 }
+
+/* ===================== MOBILE HEADER ===================== */
+.mobile-header {
+  display: none;
+}
+
+/* ===================== SIDEBAR OVERLAY ===================== */
+.sidebar-overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.4);
+  z-index: 99;
+  backdrop-filter: blur(2px);
+}
+
+/* ===================== RESPONSIVE ===================== */
+@media (max-width: 768px) {
+  .mobile-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: var(--space-3) var(--space-4);
+    background: var(--bg-card);
+    border-bottom: 1px solid var(--border);
+    position: sticky;
+    top: 0;
+    z-index: 50;
+  }
+
+  .mobile-logo {
+    font-family: var(--font-display);
+    font-size: 18px;
+    color: var(--text-primary);
+  }
+
+  .hamburger-btn {
+    background: none;
+    border: none;
+    cursor: pointer;
+    font-size: 20px;
+    color: var(--text-primary);
+    padding: var(--space-1) var(--space-2);
+    line-height: 1;
+  }
+
+  .sidebar {
+    transform: translateX(-100%);
+    transition: transform 0.25s ease;
+  }
+
+  .sidebar.is-open {
+    transform: translateX(0);
+    z-index: 100;
+  }
+
+  .main-content {
+    margin-left: 0;
+    padding: var(--space-4);
+  }
+
+  .grid-2 {
+    grid-template-columns: 1fr;
+  }
+
+  .grid-3 {
+    grid-template-columns: 1fr;
+  }
+
+  .page-header h2 {
+    font-size: 22px;
+  }
+}


### PR DESCRIPTION
Implements a responsive mobile layout with a slide-in sidebar triggered by a hamburger menu button. On desktop the layout is unchanged. On mobile (≤768px):

- A sticky top bar appears with the app name, hamburger toggle, and dark mode button
- The sidebar slides in from the left and can be dismissed by tapping the backdrop or navigating
- The main content takes full width
- Two- and three-column grids collapse to one column

Closes #22

Generated with [Claude Code](https://claude.ai/code)