### PR TITLE
feat: Add responsive mobile layout with top nav

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -6,24 +6,24 @@ import Cats from './pages/Cats'
 import './index.css'
 import './App.css'
 
-function Sidebar({ darkMode, onToggleDarkMode, isOpen, onClose }) {
+function Sidebar({ darkMode, onToggleDarkMode }) {
   return (
-    <aside className={`sidebar${isOpen ? ' is-open' : ''}`}>
+    <aside className="sidebar">
       <div className="sidebar-logo">
         <h1>litterbox</h1>
         <p>cat health monitor</p>
       </div>
 
       <nav className="sidebar-nav">
-        <NavLink to="/" end className={({ isActive }) => `nav-item ${isActive ? 'active' : ''}`} onClick={onClose}>
+        <NavLink to="/" end className={({ isActive }) => `nav-item ${isActive ? 'active' : ''}`}>
           <span className="nav-icon">📊</span>
           Dashboard
         </NavLink>
-        <NavLink to="/visits" className={({ isActive }) => `nav-item ${isActive ? 'active' : ''}`} onClick={onClose}>
+        <NavLink to="/visits" className={({ isActive }) => `nav-item ${isActive ? 'active' : ''}`}>
           <span className="nav-icon">📋</span>
           Visits
         </NavLink>
-        <NavLink to="/cats" className={({ isActive }) => `nav-item ${isActive ? 'active' : ''}`} onClick={onClose}>
+        <NavLink to="/cats" className={({ isActive }) => `nav-item ${isActive ? 'active' : ''}`}>
           <span className="nav-icon">🐱</span>
           Cats
         </NavLink>
@@ -46,7 +46,6 @@ function AppShell() {
   const [darkMode, setDarkMode] = useState(() => {
     return localStorage.getItem('theme') === 'dark'
   })
-  const [sidebarOpen, setSidebarOpen] = useState(false)
 
   useEffect(() => {
     document.documentElement.setAttribute('data-theme', darkMode ? 'dark' : 'light')
@@ -56,9 +55,6 @@ function AppShell() {
   return (
     <div className="app-shell">
       <header className="mobile-header">
-        <button className="hamburger-btn" onClick={() => setSidebarOpen(true)} aria-label="Open menu">
-          ☰
-        </button>
         <span className="mobile-logo">litterbox</span>
         <button
           className="btn btn-secondary btn-sm"
@@ -69,15 +65,9 @@ function AppShell() {
         </button>
       </header>
 
-      {sidebarOpen && (
-        <div className="sidebar-overlay" onClick={() => setSidebarOpen(false)} />
-      )}
-
       <Sidebar
         darkMode={darkMode}
         onToggleDarkMode={() => setDarkMode(d => !d)}
-        isOpen={sidebarOpen}
-        onClose={() => setSidebarOpen(false)}
       />
       <main className="main-content">
         <Routes>

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -406,17 +406,12 @@ body {
   display: none;
 }
 
-/* ===================== SIDEBAR OVERLAY ===================== */
-.sidebar-overlay {
-  position: fixed;
-  inset: 0;
-  background: rgba(0, 0, 0, 0.4);
-  z-index: 99;
-  backdrop-filter: blur(2px);
-}
-
 /* ===================== RESPONSIVE ===================== */
 @media (max-width: 768px) {
+  .app-shell {
+    flex-direction: column;
+  }
+
   .mobile-header {
     display: flex;
     align-items: center;
@@ -424,9 +419,6 @@ body {
     padding: var(--space-3) var(--space-4);
     background: var(--bg-card);
     border-bottom: 1px solid var(--border);
-    position: sticky;
-    top: 0;
-    z-index: 50;
   }
 
   .mobile-logo {
@@ -435,24 +427,30 @@ body {
     color: var(--text-primary);
   }
 
-  .hamburger-btn {
-    background: none;
-    border: none;
-    cursor: pointer;
-    font-size: 20px;
-    color: var(--text-primary);
-    padding: var(--space-1) var(--space-2);
-    line-height: 1;
-  }
-
   .sidebar {
-    transform: translateX(-100%);
-    transition: transform 0.25s ease;
+    position: relative;
+    width: 100%;
+    height: auto;
+    flex-direction: row;
+    align-items: center;
+    border-right: none;
+    border-bottom: 1px solid var(--border);
+    z-index: auto;
   }
 
-  .sidebar.is-open {
-    transform: translateX(0);
-    z-index: 100;
+  .sidebar-logo {
+    display: none;
+  }
+
+  .sidebar-nav {
+    display: flex;
+    flex-direction: row;
+    flex: 1;
+    padding: var(--space-2) var(--space-3);
+  }
+
+  .sidebar-footer {
+    display: none;
   }
 
   .main-content {


### PR DESCRIPTION
On mobile, replaces the hamburger slide-in sidebar with an always-visible horizontal nav bar at the top of the screen. The app shell stacks vertically: logo header → nav tabs → main content. Desktop layout is unchanged.

Closes #22

Generated with [Claude Code](https://claude.ai/code)