### PR TITLE
feat: add cat photo upload with canvas compression

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -34,6 +34,15 @@
   border-style: dashed;
 }
 
+.cat-card__photo--clickable {
+  cursor: pointer;
+  transition: opacity 0.15s;
+}
+
+.cat-card__photo--clickable:hover {
+  opacity: 0.75;
+}
+
 .cat-card__body {
   flex: 1;
   min-width: 0;

--- a/frontend/src/components/CatCard.jsx
+++ b/frontend/src/components/CatCard.jsx
@@ -1,6 +1,26 @@
+import { useState, useEffect } from 'react'
 import { formatDistanceToNow } from 'date-fns'
+import CatPhotoUpload from './CatPhotoUpload'
 
 const PLACEHOLDER_EMOJI = '🐱'
+
+function getCatId(cat) {
+  return cat.cat_id || cat.id
+}
+
+function getStoredPhoto(catId) {
+  if (!catId) return null
+  return localStorage.getItem(`cat_photo_${catId}`) || null
+}
+
+function storePhoto(catId, dataUrl) {
+  if (!catId) return
+  if (dataUrl === null) {
+    localStorage.removeItem(`cat_photo_${catId}`)
+  } else {
+    localStorage.setItem(`cat_photo_${catId}`, dataUrl)
+  }
+}
 
 function formatDuration(seconds) {
   if (!seconds) return '—'
@@ -11,11 +31,25 @@ function formatDuration(seconds) {
 }
 
 export default function CatCard({ cat, isPlaceholder = false, onAddVisit }) {
+  const catId = getCatId(cat)
+  const [photo, setPhoto] = useState(() => getStoredPhoto(catId))
+  const [showUpload, setShowUpload] = useState(false)
+
+  useEffect(() => {
+    setPhoto(getStoredPhoto(catId))
+  }, [catId])
+
+  function handleSavePhoto(dataUrl) {
+    storePhoto(catId, dataUrl)
+    setPhoto(dataUrl)
+    setShowUpload(false)
+  }
+
   if (isPlaceholder) {
     return (
       <div className="card cat-card cat-card--placeholder">
         <div className="cat-card__photo cat-card__photo--placeholder">
-          <span>{PLACEHOLDER_EMOJI}</span>
+          {photo ? <img src={photo} alt={cat.name} /> : <span>{PLACEHOLDER_EMOJI}</span>}
         </div>
         <div className="cat-card__body">
           <div className="cat-card__name">{cat.name}</div>
@@ -30,10 +64,18 @@ export default function CatCard({ cat, isPlaceholder = false, onAddVisit }) {
     : null
 
   return (
+    <>
     <div className="card cat-card" style={{ flexDirection: 'column' }}>
       <div style={{ display: 'flex', gap: 'var(--space-4)', alignItems: 'flex-start', width: '100%' }}>
-        <div className="cat-card__photo">
-          <span>{PLACEHOLDER_EMOJI}</span>
+        <div
+          className="cat-card__photo cat-card__photo--clickable"
+          onClick={() => setShowUpload(true)}
+          title="Click to change photo"
+          role="button"
+          tabIndex={0}
+          onKeyDown={e => e.key === 'Enter' && setShowUpload(true)}
+        >
+          {photo ? <img src={photo} alt={cat.cat_name || cat.name} /> : <span>{PLACEHOLDER_EMOJI}</span>}
         </div>
 
         <div className="cat-card__body">
@@ -92,5 +134,14 @@ export default function CatCard({ cat, isPlaceholder = false, onAddVisit }) {
         </button>
       )}
     </div>
+
+    {showUpload && (
+      <CatPhotoUpload
+        catName={cat.cat_name || cat.name}
+        onClose={() => setShowUpload(false)}
+        onSave={handleSavePhoto}
+      />
+    )}
+    </>
   )
 }

--- a/frontend/src/components/CatPhotoUpload.jsx
+++ b/frontend/src/components/CatPhotoUpload.jsx
@@ -1,0 +1,122 @@
+import { useRef, useState } from 'react'
+
+const MAX_DIMENSION = 1000
+const ACCEPTED_TYPES = ['image/jpeg', 'image/png', 'image/gif', 'image/webp', 'image/avif', 'image/bmp', 'image/tiff']
+
+function compressImage(file) {
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader()
+    reader.onload = (e) => {
+      const img = new Image()
+      img.onload = () => {
+        let { width, height } = img
+        if (width > MAX_DIMENSION || height > MAX_DIMENSION) {
+          if (width > height) {
+            height = Math.round((height * MAX_DIMENSION) / width)
+            width = MAX_DIMENSION
+          } else {
+            width = Math.round((width * MAX_DIMENSION) / height)
+            height = MAX_DIMENSION
+          }
+        }
+        const canvas = document.createElement('canvas')
+        canvas.width = width
+        canvas.height = height
+        canvas.getContext('2d').drawImage(img, 0, 0, width, height)
+        resolve(canvas.toDataURL('image/jpeg', 0.85))
+      }
+      img.onerror = () => reject(new Error('Could not load image'))
+      img.src = e.target.result
+    }
+    reader.onerror = () => reject(new Error('Could not read file'))
+    reader.readAsDataURL(file)
+  })
+}
+
+export default function CatPhotoUpload({ catName, onClose, onSave }) {
+  const [error, setError] = useState(null)
+  const [preview, setPreview] = useState(null)
+  const [processing, setProcessing] = useState(false)
+  const inputRef = useRef(null)
+
+  async function handleFile(e) {
+    const file = e.target.files?.[0]
+    if (!file) return
+
+    if (!file.type.startsWith('image/') || !ACCEPTED_TYPES.includes(file.type)) {
+      setError('Please select a valid image file (JPEG, PNG, GIF, WebP, etc.)')
+      e.target.value = ''
+      return
+    }
+
+    setError(null)
+    setProcessing(true)
+    try {
+      const compressed = await compressImage(file)
+      setPreview(compressed)
+    } catch {
+      setError('Failed to process image. Please try a different file.')
+    } finally {
+      setProcessing(false)
+      e.target.value = ''
+    }
+  }
+
+  return (
+    <div className="modal-overlay" onClick={onClose}>
+      <div className="modal" onClick={e => e.stopPropagation()}>
+        <div className="modal-title">Cat photo</div>
+        <p className="text-muted" style={{ fontSize: 13, marginBottom: 16 }}>
+          {catName ? `Upload a photo of ${catName}` : 'Upload a photo of your cat'}, or use the
+          default icon. Large images are automatically compressed to max {MAX_DIMENSION}×{MAX_DIMENSION}px.
+        </p>
+
+        <div style={{ display: 'flex', flexDirection: 'column', gap: 12 }}>
+          {preview && (
+            <div style={{ textAlign: 'center' }}>
+              <img
+                src={preview}
+                alt="Preview"
+                style={{ maxWidth: '100%', maxHeight: 200, borderRadius: 8, objectFit: 'cover' }}
+              />
+            </div>
+          )}
+
+          <button
+            className="btn btn-secondary w-full"
+            onClick={() => inputRef.current?.click()}
+            disabled={processing}
+          >
+            {processing ? 'Processing…' : preview ? 'Choose different photo' : 'Choose photo'}
+          </button>
+
+          <input
+            ref={inputRef}
+            type="file"
+            accept="image/*"
+            style={{ display: 'none' }}
+            onChange={handleFile}
+          />
+
+          {error && (
+            <p style={{ fontSize: 12, color: 'var(--red)', margin: 0 }}>{error}</p>
+          )}
+
+          {preview && (
+            <button className="btn btn-primary w-full" onClick={() => onSave(preview)}>
+              Use this photo
+            </button>
+          )}
+
+          <button className="btn btn-secondary w-full" onClick={() => onSave(null)}>
+            Use default icon
+          </button>
+
+          <button className="btn btn-secondary w-full" onClick={onClose}>
+            Cancel
+          </button>
+        </div>
+      </div>
+    </div>
+  )
+}


### PR DESCRIPTION
Allow users to upload a custom photo for each cat on the dashboard. Clicking the cat's photo area opens a modal with options to upload an image or revert to the default icon. Uploaded images are validated by MIME type, compressed via the canvas API to a max of 1000×1000px, and stored as base64 in localStorage keyed by cat ID.

Closes #24

Generated with [Claude Code](https://claude.ai/code)