### PR TITLE
Add test suite for TDD

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,97 @@
 # litterbox
 
 Attempting to connect to a viervoeter Litterbox
+
+## Running the test suite
+
+### Prerequisites
+
+Install the main dependencies and the test-only extras:
+
+```bash
+pip install -r requirements.txt -r requirements-test.txt
+```
+
+The test suite uses an in-memory SQLite database and mocks out the Tuya cloud
+connection, so **no real device or database is required** to run tests.
+
+### Run all tests
+
+```bash
+pytest
+```
+
+### Run with verbose output
+
+```bash
+pytest -v
+```
+
+### Run a specific test file
+
+```bash
+pytest tests/test_api_cats.py -v
+pytest tests/test_poller.py -v
+```
+
+### Run a specific test
+
+```bash
+pytest tests/test_poller.py::TestHandleWeightUpdate::test_creates_new_visit_on_first_weight -v
+```
+
+### Test files
+
+| File | What it covers |
+|---|---|
+| `tests/test_cat_identifier.py` | `identify_cat` and `update_reference_weight` pure logic |
+| `tests/test_health.py` | `/health` endpoint |
+| `tests/test_api_cats.py` | `/cats` CRUD endpoints |
+| `tests/test_api_visits.py` | `/visits` CRUD + weight history endpoints |
+| `tests/test_api_cleaning_cycles.py` | `/cleaning-cycles` listing endpoint |
+| `tests/test_api_dashboard.py` | `/dashboard` aggregation endpoint |
+| `tests/test_poller.py` | `LitterboxPoller` state-machine logic |
+
+---
+
+## Tests that need owner input
+
+The following areas have placeholder assumptions in the tests. Each test file
+has a docstring explaining the uncertainty, but a summary is below.
+
+### 1. Real device DP values (`tests/test_poller.py`)
+
+The poller tests assume:
+- `cat_weight` is reported in **grams** as an integer (e.g. `4200` → 4.2 kg)
+- `excretion_time_day` is reported in **seconds** as an integer
+- `smart_clean` is `True` when a cleaning cycle starts and `False` when it ends
+
+If the real Tuya device behaves differently, update `tests/test_poller.py`
+and possibly the conversion logic in `poller.py`.
+
+### 2. Cat reference weights (`tests/test_api_cats.py`, `tests/test_poller.py`)
+
+Tests use placeholder cats named "Luna" (4.0 kg) and "Mochi" (6.0 kg).
+Once real cats are registered, you may want to add regression tests with
+their actual weights to ensure the identification threshold (currently 0.5 kg)
+keeps working correctly.
+
+### 3. Poller health threshold (`tests/test_api_dashboard.py`)
+
+`POLLER_HEALTHY_THRESHOLD_SECONDS` is set to **30 seconds** in
+`app/routers/dashboard.py`, but the default polling interval is **300 seconds**.
+This means the dashboard will show the poller as unhealthy for most of each
+poll cycle. Confirm whether this is intentional, or if the threshold should
+be raised to something like 600 seconds.
+
+### 4. Unidentified visit handling (`tests/test_api_dashboard.py`)
+
+The dashboard counts unidentified visits where `ended_at IS NOT NULL`. Visits
+that are still in progress (no `ended_at`) are excluded. Confirm this matches
+the expected dashboard behaviour.
+
+### 5. Reference weight smoothing factor (`tests/test_cat_identifier.py`)
+
+`update_reference_weight` uses a default smoothing of `0.1`. If you observe
+rapid weight fluctuations with the real device (e.g. due to scale jitter),
+you may want to tune this value and add a regression test for the chosen value.

--- a/conftest.py
+++ b/conftest.py
@@ -1,0 +1,60 @@
+import os
+
+# Must be set before any app imports — database.py and poller.py raise at module level
+os.environ.setdefault("DATABASE_URL", "sqlite:///:memory:")
+os.environ.setdefault("TUYA_DEVICE_ID", "test_device_id")
+os.environ.setdefault("TUYA_API_KEY", "test_api_key")
+os.environ.setdefault("TUYA_API_SECRET", "test_api_secret")
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+from sqlalchemy.pool import StaticPool
+from starlette.testclient import TestClient
+
+from app.models import Base
+
+# In-memory SQLite with a single shared connection — isolates tests without
+# needing a real Postgres instance.
+TEST_ENGINE = create_engine(
+    "sqlite:///:memory:",
+    connect_args={"check_same_thread": False},
+    poolclass=StaticPool,
+)
+TestingSessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=TEST_ENGINE)
+
+
+@pytest.fixture
+def db():
+    """Yields a database session with a clean schema for each test."""
+    Base.metadata.create_all(bind=TEST_ENGINE)
+    session = TestingSessionLocal()
+    try:
+        yield session
+    finally:
+        session.close()
+        Base.metadata.drop_all(bind=TEST_ENGINE)
+
+
+@pytest.fixture
+def client(db):
+    """
+    Yields a FastAPI TestClient with:
+    - get_db overridden to use the in-memory test database
+    - run_poller patched out so no background thread or Tuya calls happen
+    """
+    from app.database import get_db
+    from app.main import app
+
+    def override_get_db():
+        yield db
+
+    app.dependency_overrides[get_db] = override_get_db
+
+    with patch("app.main.run_poller"):
+        with TestClient(app) as c:
+            yield c
+
+    app.dependency_overrides.clear()

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,0 +1,5 @@
+# Test dependencies — install alongside requirements.txt
+# pip install -r requirements.txt -r requirements-test.txt
+pytest==8.3.5
+httpx==0.28.1
+anyio==4.8.0

--- a/tests/test_api_cats.py
+++ b/tests/test_api_cats.py
@@ -1,0 +1,111 @@
+"""
+Tests for the /cats API endpoints.
+
+Functions/scenarios needing owner input:
+  - What should happen when a cat's reference_weight_kg is updated to a value
+    outside any reasonable range? (Currently no server-side validation.)
+  - Should deactivating a cat also affect its historical visits? (Currently it
+    does not — visits remain linked.)
+"""
+
+
+def test_create_cat(client):
+    response = client.post("/cats", json={"name": "Luna"})
+    assert response.status_code == 200
+    data = response.json()
+    assert data["name"] == "Luna"
+    assert data["active"] is True
+    assert data["reference_weight_kg"] is None
+    assert "id" in data
+    assert "created_at" in data
+
+
+def test_create_cat_with_reference_weight(client):
+    response = client.post("/cats", json={"name": "Mochi", "reference_weight_kg": 5.5})
+    assert response.status_code == 200
+    assert response.json()["reference_weight_kg"] == 5.5
+
+
+def test_list_cats_returns_only_active_by_default(client):
+    client.post("/cats", json={"name": "Active"})
+    # Create and deactivate a second cat
+    r = client.post("/cats", json={"name": "Inactive"})
+    cat_id = r.json()["id"]
+    client.patch(f"/cats/{cat_id}", json={"active": False})
+
+    response = client.get("/cats")
+    assert response.status_code == 200
+    names = [c["name"] for c in response.json()]
+    assert "Active" in names
+    assert "Inactive" not in names
+
+
+def test_list_cats_include_inactive(client):
+    client.post("/cats", json={"name": "Active"})
+    r = client.post("/cats", json={"name": "Inactive"})
+    cat_id = r.json()["id"]
+    client.patch(f"/cats/{cat_id}", json={"active": False})
+
+    response = client.get("/cats", params={"include_inactive": True})
+    assert response.status_code == 200
+    names = [c["name"] for c in response.json()]
+    assert "Active" in names
+    assert "Inactive" in names
+
+
+def test_get_cat(client):
+    r = client.post("/cats", json={"name": "Luna"})
+    cat_id = r.json()["id"]
+
+    response = client.get(f"/cats/{cat_id}")
+    assert response.status_code == 200
+    assert response.json()["name"] == "Luna"
+
+
+def test_get_cat_not_found(client):
+    response = client.get("/cats/9999")
+    assert response.status_code == 404
+    assert "not found" in response.json()["detail"].lower()
+
+
+def test_update_cat_name(client):
+    r = client.post("/cats", json={"name": "Luna"})
+    cat_id = r.json()["id"]
+
+    response = client.patch(f"/cats/{cat_id}", json={"name": "Luna Updated"})
+    assert response.status_code == 200
+    assert response.json()["name"] == "Luna Updated"
+
+
+def test_update_cat_reference_weight(client):
+    r = client.post("/cats", json={"name": "Luna"})
+    cat_id = r.json()["id"]
+
+    response = client.patch(f"/cats/{cat_id}", json={"reference_weight_kg": 4.2})
+    assert response.status_code == 200
+    assert response.json()["reference_weight_kg"] == 4.2
+
+
+def test_update_cat_deactivate(client):
+    r = client.post("/cats", json={"name": "Luna"})
+    cat_id = r.json()["id"]
+
+    response = client.patch(f"/cats/{cat_id}", json={"active": False})
+    assert response.status_code == 200
+    assert response.json()["active"] is False
+
+
+def test_update_cat_not_found(client):
+    response = client.patch("/cats/9999", json={"name": "Ghost"})
+    assert response.status_code == 404
+
+
+def test_create_multiple_cats_appear_in_list(client):
+    client.post("/cats", json={"name": "Luna"})
+    client.post("/cats", json={"name": "Mochi"})
+
+    response = client.get("/cats")
+    assert response.status_code == 200
+    names = [c["name"] for c in response.json()]
+    assert "Luna" in names
+    assert "Mochi" in names

--- a/tests/test_api_cleaning_cycles.py
+++ b/tests/test_api_cleaning_cycles.py
@@ -1,0 +1,60 @@
+"""Tests for the /cleaning-cycles API endpoint."""
+from datetime import datetime, timezone
+
+from app.models import CleaningCycle
+
+
+def test_list_cleaning_cycles_empty(client):
+    response = client.get("/cleaning-cycles")
+    assert response.status_code == 200
+    assert response.json() == []
+
+
+def test_list_cleaning_cycles(client, db):
+    now = datetime.now(timezone.utc)
+    db.add(CleaningCycle(started_at=now))
+    db.commit()
+
+    response = client.get("/cleaning-cycles")
+    assert response.status_code == 200
+    data = response.json()
+    assert len(data) == 1
+    assert data[0]["ended_at"] is None
+
+
+def test_list_cleaning_cycles_completed(client, db):
+    from datetime import timedelta
+    start = datetime(2024, 1, 15, 10, 0, 0, tzinfo=timezone.utc)
+    end = start + timedelta(minutes=5)
+    db.add(CleaningCycle(started_at=start, ended_at=end))
+    db.commit()
+
+    response = client.get("/cleaning-cycles")
+    assert response.status_code == 200
+    data = response.json()
+    assert data[0]["ended_at"] is not None
+
+
+def test_list_cleaning_cycles_respects_limit(client, db):
+    from datetime import timedelta
+    now = datetime.now(timezone.utc)
+    for i in range(5):
+        db.add(CleaningCycle(started_at=now + timedelta(minutes=i)))
+    db.commit()
+
+    response = client.get("/cleaning-cycles", params={"limit": 2})
+    assert response.status_code == 200
+    assert len(response.json()) == 2
+
+
+def test_list_cleaning_cycles_ordered_newest_first(client, db):
+    from datetime import timedelta
+    base = datetime(2024, 1, 15, 10, 0, 0, tzinfo=timezone.utc)
+    db.add(CleaningCycle(started_at=base))
+    db.add(CleaningCycle(started_at=base + timedelta(hours=1)))
+    db.commit()
+
+    response = client.get("/cleaning-cycles")
+    data = response.json()
+    # Most recent should be first
+    assert data[0]["started_at"] > data[1]["started_at"]

--- a/tests/test_api_dashboard.py
+++ b/tests/test_api_dashboard.py
@@ -1,0 +1,155 @@
+"""
+Tests for the /dashboard endpoint.
+
+Functions/scenarios needing owner input:
+  - POLLER_HEALTHY_THRESHOLD_SECONDS is 30 seconds. Is this threshold appropriate
+    for the polling interval configured in production? If POLL_INTERVAL_SECONDS
+    is 300, the dashboard will almost always show the poller as unhealthy in
+    tests (and in practice, between polls). Confirm whether this is intentional
+    or if the threshold should be adjusted.
+  - Should the dashboard count visits that are still in progress (ended_at=None)
+    toward visits_today and time_in_box_today_seconds?
+"""
+from datetime import datetime, timezone, timedelta
+
+import pytest
+
+from app.models import Cat, Visit, CleaningCycle
+
+
+def _add_cat(db, name="TestCat", weight=4.0):
+    cat = Cat(name=name, reference_weight_kg=weight)
+    db.add(cat)
+    db.commit()
+    db.refresh(cat)
+    return cat
+
+
+def _add_visit(db, cat, started_at, duration_seconds=120, weight_kg=4.0, ended_at=None):
+    v = Visit(
+        cat_id=cat.id,
+        started_at=started_at,
+        ended_at=ended_at or started_at + timedelta(seconds=duration_seconds),
+        duration_seconds=duration_seconds,
+        weight_kg=weight_kg,
+        identified_by="auto",
+    )
+    db.add(v)
+    db.commit()
+    db.refresh(v)
+    return v
+
+
+def test_dashboard_no_cats(client):
+    response = client.get("/dashboard")
+    assert response.status_code == 200
+    data = response.json()
+    assert data["cats"] == []
+    assert data["unidentified_visits_today"] == 0
+    assert data["cleaning_cycles_today"] == 0
+    assert data["poller_healthy"] is False  # no poll has happened in tests
+    assert "generated_at" in data
+
+
+def test_dashboard_shows_active_cats_only(client, db):
+    _add_cat(db, name="Active")
+    inactive = _add_cat(db, name="Inactive")
+    inactive.active = False
+    db.commit()
+
+    response = client.get("/dashboard")
+    data = response.json()
+    names = [c["cat_name"] for c in data["cats"]]
+    assert "Active" in names
+    assert "Inactive" not in names
+
+
+def test_dashboard_visits_today(client, db):
+    cat = _add_cat(db)
+    today_start = datetime.now(timezone.utc).replace(hour=0, minute=0, second=0, microsecond=0)
+
+    _add_visit(db, cat, started_at=today_start + timedelta(hours=1))
+    _add_visit(db, cat, started_at=today_start + timedelta(hours=3))
+
+    response = client.get("/dashboard")
+    data = response.json()
+    cat_data = data["cats"][0]
+    assert cat_data["visits_today"] == 2
+
+
+def test_dashboard_time_in_box_today(client, db):
+    cat = _add_cat(db)
+    today_start = datetime.now(timezone.utc).replace(hour=0, minute=0, second=0, microsecond=0)
+
+    _add_visit(db, cat, started_at=today_start + timedelta(hours=1), duration_seconds=60)
+    _add_visit(db, cat, started_at=today_start + timedelta(hours=2), duration_seconds=90)
+
+    response = client.get("/dashboard")
+    data = response.json()
+    cat_data = data["cats"][0]
+    assert cat_data["time_in_box_today_seconds"] == 150
+
+
+def test_dashboard_excludes_yesterday_visits(client, db):
+    cat = _add_cat(db)
+    yesterday = datetime.now(timezone.utc) - timedelta(days=1)
+    _add_visit(db, cat, started_at=yesterday)
+
+    response = client.get("/dashboard")
+    data = response.json()
+    cat_data = data["cats"][0]
+    assert cat_data["visits_today"] == 0
+    assert cat_data["time_in_box_today_seconds"] == 0
+
+
+def test_dashboard_last_visit(client, db):
+    cat = _add_cat(db)
+    today_start = datetime.now(timezone.utc).replace(hour=0, minute=0, second=0, microsecond=0)
+    _add_visit(db, cat, started_at=today_start + timedelta(hours=1), weight_kg=4.2, duration_seconds=75)
+
+    response = client.get("/dashboard")
+    data = response.json()
+    cat_data = data["cats"][0]
+    assert cat_data["last_visit_weight_kg"] == 4.2
+    assert cat_data["last_visit_duration_seconds"] == 75
+    assert cat_data["last_visit_at"] is not None
+
+
+def test_dashboard_unidentified_visits_today(client, db):
+    today_start = datetime.now(timezone.utc).replace(hour=0, minute=0, second=0, microsecond=0)
+    v = Visit(
+        cat_id=None,
+        started_at=today_start + timedelta(hours=1),
+        ended_at=today_start + timedelta(hours=1, minutes=2),
+        duration_seconds=120,
+        weight_kg=3.5,
+    )
+    db.add(v)
+    db.commit()
+
+    response = client.get("/dashboard")
+    data = response.json()
+    assert data["unidentified_visits_today"] == 1
+
+
+def test_dashboard_cleaning_cycles_today(client, db):
+    today_start = datetime.now(timezone.utc).replace(hour=0, minute=0, second=0, microsecond=0)
+    db.add(CleaningCycle(started_at=today_start + timedelta(hours=2)))
+    db.add(CleaningCycle(started_at=today_start + timedelta(hours=4)))
+    db.commit()
+
+    response = client.get("/dashboard")
+    data = response.json()
+    assert data["cleaning_cycles_today"] == 2
+
+
+def test_dashboard_poller_healthy(client):
+    import app.routers.dashboard as dashboard_state
+    dashboard_state.last_successful_poll_at = datetime.now(timezone.utc)
+
+    response = client.get("/dashboard")
+    data = response.json()
+    assert data["poller_healthy"] is True
+
+    # Clean up
+    dashboard_state.last_successful_poll_at = None

--- a/tests/test_api_visits.py
+++ b/tests/test_api_visits.py
@@ -1,0 +1,180 @@
+"""
+Tests for the /visits API endpoints.
+
+Functions/scenarios needing owner input:
+  - What is a realistic weight range for visits? (Currently no server-side
+    validation — any float is accepted including negative values.)
+  - Should weight_history respect cat inactivity, or always include all cats
+    that have historical visits regardless of active status?
+  - What should list_visits return when limit=0? (Currently returns 0 rows —
+    confirm this is the desired behaviour.)
+"""
+from datetime import datetime, timezone
+
+
+def _make_cat(client, name="TestCat", weight=4.0):
+    r = client.post("/cats", json={"name": name, "reference_weight_kg": weight})
+    assert r.status_code == 200
+    return r.json()["id"]
+
+
+def _make_visit(client, cat_id, weight_kg=4.0, duration_seconds=120):
+    payload = {
+        "cat_id": cat_id,
+        "started_at": "2024-01-15T10:00:00Z",
+        "duration_seconds": duration_seconds,
+        "weight_kg": weight_kg,
+    }
+    r = client.post("/visits", json=payload)
+    assert r.status_code == 201
+    return r.json()["id"]
+
+
+# --- create ---
+
+def test_create_visit(client):
+    cat_id = _make_cat(client)
+    payload = {
+        "cat_id": cat_id,
+        "started_at": "2024-01-15T10:00:00Z",
+        "duration_seconds": 90,
+        "weight_kg": 4.1,
+    }
+    response = client.post("/visits", json=payload)
+    assert response.status_code == 201
+    data = response.json()
+    assert data["cat_id"] == cat_id
+    assert data["weight_kg"] == 4.1
+    assert data["duration_seconds"] == 90
+    assert data["identified_by"] == "manual"
+
+
+# --- list ---
+
+def test_list_visits_empty(client):
+    response = client.get("/visits")
+    assert response.status_code == 200
+    assert response.json() == []
+
+
+def test_list_visits(client):
+    cat_id = _make_cat(client)
+    _make_visit(client, cat_id)
+    _make_visit(client, cat_id)
+
+    response = client.get("/visits")
+    assert response.status_code == 200
+    assert len(response.json()) == 2
+
+
+def test_list_visits_filter_by_cat(client):
+    cat_a = _make_cat(client, name="CatA")
+    cat_b = _make_cat(client, name="CatB")
+    _make_visit(client, cat_a)
+    _make_visit(client, cat_b)
+
+    response = client.get("/visits", params={"cat_id": cat_a})
+    assert response.status_code == 200
+    visits = response.json()
+    assert len(visits) == 1
+    assert visits[0]["cat_id"] == cat_a
+
+
+def test_list_visits_respects_limit(client):
+    cat_id = _make_cat(client)
+    for _ in range(5):
+        _make_visit(client, cat_id)
+
+    response = client.get("/visits", params={"limit": 3})
+    assert response.status_code == 200
+    assert len(response.json()) == 3
+
+
+# --- get single ---
+
+def test_get_visit(client):
+    cat_id = _make_cat(client)
+    visit_id = _make_visit(client, cat_id)
+
+    response = client.get(f"/visits/{visit_id}")
+    assert response.status_code == 200
+    assert response.json()["id"] == visit_id
+
+
+def test_get_visit_not_found(client):
+    response = client.get("/visits/9999")
+    assert response.status_code == 404
+
+
+# --- update ---
+
+def test_update_visit_reassigns_cat(client):
+    cat_a = _make_cat(client, name="CatA")
+    cat_b = _make_cat(client, name="CatB")
+    visit_id = _make_visit(client, cat_a)
+
+    response = client.patch(f"/visits/{visit_id}", json={"cat_id": cat_b})
+    assert response.status_code == 200
+    data = response.json()
+    assert data["cat_id"] == cat_b
+    assert data["identified_by"] == "manual"
+
+
+def test_update_visit_not_found(client):
+    response = client.patch("/visits/9999", json={"cat_id": 1})
+    assert response.status_code == 404
+
+
+# --- delete ---
+
+def test_delete_visit(client):
+    cat_id = _make_cat(client)
+    visit_id = _make_visit(client, cat_id)
+
+    response = client.delete(f"/visits/{visit_id}")
+    assert response.status_code == 204
+
+    response = client.get(f"/visits/{visit_id}")
+    assert response.status_code == 404
+
+
+def test_delete_visit_not_found(client):
+    response = client.delete("/visits/9999")
+    assert response.status_code == 404
+
+
+# --- weight history ---
+
+def test_weight_history_returns_data_for_active_cats(client):
+    cat_id = _make_cat(client, name="Luna", weight=4.0)
+    _make_visit(client, cat_id, weight_kg=4.1)
+
+    response = client.get("/visits/weight-history")
+    assert response.status_code == 200
+    data = response.json()
+    assert len(data) == 1
+    assert data[0]["cat_name"] == "Luna"
+    assert len(data[0]["data"]) == 1
+    assert data[0]["data"][0]["weight_kg"] == 4.1
+
+
+def test_weight_history_filter_by_cat(client):
+    cat_a = _make_cat(client, name="CatA")
+    cat_b = _make_cat(client, name="CatB")
+    _make_visit(client, cat_a)
+    _make_visit(client, cat_b)
+
+    response = client.get("/visits/weight-history", params={"cat_id": cat_a})
+    assert response.status_code == 200
+    data = response.json()
+    assert len(data) == 1
+    assert data[0]["cat_name"] == "CatA"
+
+
+def test_weight_history_empty_for_no_visits(client):
+    _make_cat(client, name="Luna")
+    response = client.get("/visits/weight-history")
+    assert response.status_code == 200
+    data = response.json()
+    assert len(data) == 1
+    assert data[0]["data"] == []

--- a/tests/test_health.py
+++ b/tests/test_health.py
@@ -1,0 +1,4 @@
+def test_health(client):
+    response = client.get("/health")
+    assert response.status_code == 200
+    assert response.json() == {"status": "ok"}

--- a/tests/test_poller.py
+++ b/tests/test_poller.py
@@ -1,0 +1,269 @@
+"""
+Tests for LitterboxPoller.
+
+The Tuya Cloud connection is mocked throughout — these tests exercise the
+state-machine logic of the poller, not the network layer.
+
+Functions/scenarios needing owner input:
+  - What does the real Tuya device return for `cat_weight`, `excretion_times_day`,
+    and `excretion_time_day`? The tests assume raw weight in grams (e.g. 4200 → 4.2 kg)
+    and integer seconds for duration. Confirm these match the real device behaviour.
+  - VISIT_TIMEOUT_SECONDS is 300. Should tests cover shorter timeouts for faster
+    iteration, or is the production value the only one that matters?
+  - Should _handle_visit_complete create a visit when `excretion_time_day` is
+    missing (None) from the DPS? Currently it stores duration_seconds=None.
+  - What DP values trigger cleaning cycle start/end? The tests assume `smart_clean`
+    is True to start and False to end — confirm this matches the real device.
+"""
+import os
+from datetime import datetime, timezone, timedelta
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from app.models import Cat, CleaningCycle, DeviceSnapshot, SettingsHistory, Visit
+from app.poller import (
+    DP_CAT_WEIGHT,
+    DP_CLEANING_CYCLE,
+    DP_EXCRETION_TIME,
+    DP_EXCRETION_TIMES,
+    SNAPSHOT_INTERVAL_SECONDS,
+    VISIT_TIMEOUT_SECONDS,
+    LitterboxPoller,
+)
+
+
+@pytest.fixture
+def mock_cloud():
+    """Patches make_cloud so no real Tuya calls are made."""
+    with patch("app.poller.make_cloud") as mock_make:
+        instance = MagicMock()
+        instance.getstatus.return_value = {"success": True, "result": []}
+        mock_make.return_value = instance
+        yield instance
+
+
+@pytest.fixture
+def poller(db, mock_cloud):
+    return LitterboxPoller(db)
+
+
+def _now():
+    return datetime.now(timezone.utc)
+
+
+# ---------------------------------------------------------------------------
+# Weight update
+# ---------------------------------------------------------------------------
+
+class TestHandleWeightUpdate:
+    def test_creates_new_visit_on_first_weight(self, poller, db):
+        now = _now()
+        poller._handle_weight_update(4200, now)  # 4200g → 4.2 kg
+
+        visits = db.query(Visit).all()
+        assert len(visits) == 1
+        assert visits[0].weight_kg == pytest.approx(4.2)
+        assert visits[0].started_at == now
+
+    def test_updates_weight_on_existing_visit(self, poller, db):
+        now = _now()
+        poller._handle_weight_update(4200, now)
+        poller._handle_weight_update(4300, now)  # updated reading
+
+        visits = db.query(Visit).all()
+        assert len(visits) == 1
+        assert visits[0].weight_kg == pytest.approx(4.3)
+
+    def test_records_last_weight_at(self, poller):
+        now = _now()
+        poller._handle_weight_update(4000, now)
+        assert poller.last_weight_at == now
+
+
+# ---------------------------------------------------------------------------
+# Visit completion
+# ---------------------------------------------------------------------------
+
+class TestHandleVisitComplete:
+    def test_closes_existing_visit(self, poller, db):
+        now = _now()
+        poller._handle_weight_update(4200, now)
+        assert poller.current_visit is not None
+
+        dps = {DP_EXCRETION_TIME: 90, DP_CAT_WEIGHT: 4200}
+        complete_time = now + timedelta(seconds=90)
+        poller._handle_visit_complete(dps, complete_time)
+
+        assert poller.current_visit is None
+        visit = db.query(Visit).first()
+        assert visit.ended_at == complete_time
+        assert visit.duration_seconds == 90
+
+    def test_creates_visit_when_weight_was_missed(self, poller, db):
+        """If we missed the weight DP, visit complete should still record the visit."""
+        assert poller.current_visit is None
+        dps = {DP_EXCRETION_TIME: 60, DP_CAT_WEIGHT: 4000}
+        poller._handle_visit_complete(dps, _now())
+
+        visits = db.query(Visit).all()
+        assert len(visits) == 1
+        assert visits[0].weight_kg == pytest.approx(4.0)
+
+    def test_assigns_cat_when_weight_matches(self, poller, db):
+        cat = Cat(name="Luna", reference_weight_kg=4.0, active=True)
+        db.add(cat)
+        db.commit()
+
+        now = _now()
+        poller._handle_weight_update(4100, now)  # 4.1 kg — within 0.5 kg threshold
+        dps = {DP_EXCRETION_TIME: 75, DP_CAT_WEIGHT: 4100}
+        poller._handle_visit_complete(dps, now + timedelta(seconds=75))
+
+        visit = db.query(Visit).first()
+        assert visit.cat_id == cat.id
+        assert visit.identified_by == "auto"
+
+
+# ---------------------------------------------------------------------------
+# Visit timeout
+# ---------------------------------------------------------------------------
+
+class TestCheckVisitTimeout:
+    def test_closes_visit_after_timeout(self, poller, db):
+        start = _now()
+        poller._handle_weight_update(4200, start)
+        assert poller.current_visit is not None
+
+        # Simulate time passing beyond timeout
+        later = start + timedelta(seconds=VISIT_TIMEOUT_SECONDS + 1)
+        poller._check_visit_timeout(later)
+
+        assert poller.current_visit is None
+        visit = db.query(Visit).first()
+        assert visit.ended_at is not None
+
+    def test_does_not_close_visit_before_timeout(self, poller, db):
+        start = _now()
+        poller._handle_weight_update(4200, start)
+
+        just_before = start + timedelta(seconds=VISIT_TIMEOUT_SECONDS - 1)
+        poller._check_visit_timeout(just_before)
+
+        assert poller.current_visit is not None
+
+    def test_no_op_when_no_current_visit(self, poller, db):
+        poller._check_visit_timeout(_now())  # Should not raise
+        assert db.query(Visit).count() == 0
+
+
+# ---------------------------------------------------------------------------
+# Cleaning cycle
+# ---------------------------------------------------------------------------
+
+class TestHandleCleaningCycle:
+    def test_starts_cleaning_cycle(self, poller, db):
+        poller._handle_cleaning_cycle(True, _now())
+        assert poller.current_cleaning_cycle is not None
+        assert db.query(CleaningCycle).count() == 1
+
+    def test_ends_cleaning_cycle(self, poller, db):
+        start = _now()
+        poller._handle_cleaning_cycle(True, start)
+        end = start + timedelta(minutes=3)
+        poller._handle_cleaning_cycle(False, end)
+
+        assert poller.current_cleaning_cycle is None
+        cycle = db.query(CleaningCycle).first()
+        assert cycle.ended_at == end
+
+    def test_ignores_duplicate_start(self, poller, db):
+        now = _now()
+        poller._handle_cleaning_cycle(True, now)
+        poller._handle_cleaning_cycle(True, now + timedelta(seconds=5))  # already running
+
+        assert db.query(CleaningCycle).count() == 1
+
+    def test_ignores_stop_when_not_running(self, poller, db):
+        poller._handle_cleaning_cycle(False, _now())  # no cycle in progress
+        assert db.query(CleaningCycle).count() == 0
+
+
+# ---------------------------------------------------------------------------
+# Settings recording
+# ---------------------------------------------------------------------------
+
+class TestRecordSettingChange:
+    def test_records_setting(self, poller, db):
+        poller._record_setting_change("child_lock", True, _now())
+
+        entries = db.query(SettingsHistory).all()
+        assert len(entries) == 1
+        assert entries[0].dp == "child_lock"
+        assert entries[0].value == "True"
+
+    def test_records_multiple_settings(self, poller, db):
+        now = _now()
+        poller._record_setting_change("child_lock", True, now)
+        poller._record_setting_change("odourless", False, now)
+
+        assert db.query(SettingsHistory).count() == 2
+
+
+# ---------------------------------------------------------------------------
+# Snapshots
+# ---------------------------------------------------------------------------
+
+class TestMaybeSnapshot:
+    def test_saves_snapshot_on_first_poll(self, poller, db):
+        dps = {DP_CAT_WEIGHT: 0}
+        poller._maybe_snapshot(dps, _now())
+
+        assert db.query(DeviceSnapshot).count() == 1
+
+    def test_skips_snapshot_within_interval(self, poller, db):
+        now = _now()
+        poller._maybe_snapshot({}, now)
+        poller._maybe_snapshot({}, now + timedelta(seconds=10))  # too soon
+
+        assert db.query(DeviceSnapshot).count() == 1
+
+    def test_saves_snapshot_after_interval(self, poller, db):
+        now = _now()
+        poller._maybe_snapshot({}, now)
+        poller._maybe_snapshot({}, now + timedelta(seconds=SNAPSHOT_INTERVAL_SECONDS + 1))
+
+        assert db.query(DeviceSnapshot).count() == 2
+
+
+# ---------------------------------------------------------------------------
+# handle_changes dispatch
+# ---------------------------------------------------------------------------
+
+class TestHandleChanges:
+    def test_dispatches_weight_change(self, poller, db):
+        dps = {DP_CAT_WEIGHT: 4200}
+        poller._handle_changes(dps, _now())
+        assert db.query(Visit).count() == 1
+
+    def test_ignores_unchanged_dps(self, poller, db):
+        dps = {DP_CAT_WEIGHT: 4200}
+        poller.previous_dps = {DP_CAT_WEIGHT: 4200}  # same value, no change
+        poller._handle_changes(dps, _now())
+        assert db.query(Visit).count() == 0
+
+    def test_ignores_zero_weight(self, poller, db):
+        """A weight of 0 means the scale is idle — should not start a visit."""
+        dps = {DP_CAT_WEIGHT: 0}
+        poller._handle_changes(dps, _now())
+        assert db.query(Visit).count() == 0
+
+    def test_dispatches_cleaning_cycle(self, poller, db):
+        dps = {DP_CLEANING_CYCLE: True}
+        poller._handle_changes(dps, _now())
+        assert db.query(CleaningCycle).count() == 1
+
+    def test_dispatches_setting_change(self, poller, db):
+        dps = {"child_lock": True}
+        poller._handle_changes(dps, _now())
+        assert db.query(SettingsHistory).count() == 1


### PR DESCRIPTION
Closes #35

Adds a full test suite covering all API endpoints and the LitterboxPoller state machine. Tests use an in-memory SQLite database and mock the Tuya cloud - no real device required.

See README for how to run and the list of assumptions that need owner confirmation.

Generated with [Claude Code](https://claude.ai/code)