### PR TITLE
Add comprehensive test suite

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,54 @@
 # litterbox
 
 Attempting to connect to a viervoeter Litterbox
+
+## Running the test suite
+
+Install dependencies (pytest and httpx are included in `requirements.txt`):
+
+```bash
+pip install -r requirements.txt
+```
+
+Run all tests:
+
+```bash
+python3 -m pytest tests/ -v
+```
+
+Run a specific test file:
+
+```bash
+python3 -m pytest tests/test_api_cats.py -v
+python3 -m pytest tests/test_poller.py -v
+```
+
+Tests use an in-memory SQLite database and mock out the Tuya cloud connection, so no real device or credentials are needed.
+
+The test suite is also run automatically by `deploy.sh` before every deploy. If any test fails, the deploy aborts.
+
+### Test files
+
+| File | What it covers |
+|---|---|
+| `tests/test_cat_identifier.py` | `identify_cat()` and `update_reference_weight()` pure-logic tests |
+| `tests/test_health.py` | `GET /health` endpoint |
+| `tests/test_api_cats.py` | Cats CRUD (`POST /cats`, `GET /cats`, `GET /cats/{id}`, `PATCH /cats/{id}`) |
+| `tests/test_api_visits.py` | Visits CRUD + weight history endpoint |
+| `tests/test_api_cleaning_cycles.py` | `GET /cleaning-cycles` listing |
+| `tests/test_api_dashboard.py` | Dashboard aggregation (visits today, cleaning cycles, poller health) |
+| `tests/test_poller.py` | `LitterboxPoller` internal logic (visit creation, timeout, cleaning cycles, snapshots, settings) |
+
+### Areas that need your input for tests
+
+The following cannot be fully covered without real-world data or your specific setup:
+
+1. **Tuya cloud integration** — `LitterboxPoller.poll()` and `_init_cloud()` require live Tuya API credentials (`TUYA_DEVICE_ID`, `TUYA_API_KEY`, `TUYA_API_SECRET`) and a connected device. These are mocked in the current test suite. If you want end-to-end polling tests, provide credentials in a `.env` file and write integration tests tagged with `@pytest.mark.integration`.
+
+2. **Cat identification threshold** — `IDENTIFICATION_THRESHOLD_KG` is set to `0.5 kg`. If your cats have very similar weights, this threshold may need tightening and the corresponding tests in `test_cat_identifier.py` updated with real weight values.
+
+3. **Reference weight smoothing** — The exponential moving-average smoothing factor (`0.1`) controls how quickly a cat's reference weight adapts. Tests verify the math, but the right value depends on your cats' weight patterns.
+
+4. **Visit timeout** — `VISIT_TIMEOUT_SECONDS` (300 s) is a fallback for when the device doesn't send a completion event. If your device behaves differently, this constant and the related poller tests may need adjustment.
+
+5. **Frontend components** — The React components in `frontend/src/` have no automated tests. If you want component or end-to-end browser tests (e.g. with Playwright or Vitest), let me know what behaviour you want covered.

--- a/conftest.py
+++ b/conftest.py
@@ -1,0 +1,70 @@
+import os
+
+# Must be set before any app imports to avoid module-level errors
+os.environ.setdefault("DATABASE_URL", "sqlite:///:memory:")
+os.environ.setdefault("TUYA_DEVICE_ID", "test_device_id")
+os.environ.setdefault("TUYA_API_KEY", "test_api_key")
+os.environ.setdefault("TUYA_API_SECRET", "test_api_secret")
+
+import pytest
+from unittest.mock import MagicMock, patch
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+from fastapi.testclient import TestClient
+
+from app.models import Base
+from app.database import get_db
+from app.main import app
+
+
+@pytest.fixture
+def db_engine():
+    engine = create_engine(
+        "sqlite:///:memory:",
+        connect_args={"check_same_thread": False},
+    )
+    Base.metadata.create_all(engine)
+    yield engine
+    engine.dispose()
+
+
+@pytest.fixture
+def db_session(db_engine):
+    TestingSessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=db_engine)
+    session = TestingSessionLocal()
+    yield session
+    session.close()
+
+
+@pytest.fixture
+def client(db_session):
+    """FastAPI TestClient backed by an in-memory SQLite database.
+
+    The Tuya poller background thread is patched out so tests don't
+    require real device credentials.
+    """
+    def override_get_db():
+        yield db_session
+
+    app.dependency_overrides[get_db] = override_get_db
+
+    with patch("app.main.run_poller"):
+        with TestClient(app) as c:
+            yield c
+
+    app.dependency_overrides.clear()
+
+
+@pytest.fixture
+def poller(db_session):
+    """LitterboxPoller with a mocked Tuya cloud connection.
+
+    Uses the same in-memory SQLite db_session so database interactions
+    (visits, cleaning cycles, etc.) can be verified after each call.
+    """
+    mock_cloud = MagicMock()
+    mock_cloud.getstatus.return_value = {"success": True, "result": []}
+    with patch("app.poller.make_cloud", return_value=mock_cloud):
+        from app.poller import LitterboxPoller
+        p = LitterboxPoller(db_session)
+    yield p

--- a/deploy.sh
+++ b/deploy.sh
@@ -7,8 +7,14 @@ NAS_PATH="/volume2/docker/litterbox"
 
 echo "🐱 Litterbox deploy starting..."
 # pulling git data
-echo "pulling git data" 
+echo "pulling git data"
 git pull
+
+# Run tests before deploying — abort if any test fails
+echo "🧪 Running tests..."
+python3 -m pytest tests/ -v
+echo "✅ All tests passed"
+
 # Build frontend
 echo "📦 Building frontend..."
 cd frontend

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,7 @@
 alembic==1.18.4
+httpx>=0.27
+pytest>=9.0
+pytest-asyncio>=0.24
 annotated-doc==0.0.4
 annotated-types==0.7.0
 anyio==4.12.1

--- a/tests/test_api_cats.py
+++ b/tests/test_api_cats.py
@@ -1,0 +1,100 @@
+"""Tests for the /cats API endpoints."""
+
+
+def test_create_cat(client):
+    response = client.post("/cats", json={"name": "Luna", "reference_weight_kg": 4.0})
+    assert response.status_code == 200
+    data = response.json()
+    assert data["name"] == "Luna"
+    assert data["reference_weight_kg"] == 4.0
+    assert data["active"] is True
+    assert "id" in data
+    assert "created_at" in data
+
+
+def test_create_cat_without_reference_weight(client):
+    response = client.post("/cats", json={"name": "Ghost"})
+    assert response.status_code == 200
+    data = response.json()
+    assert data["name"] == "Ghost"
+    assert data["reference_weight_kg"] is None
+
+
+def test_list_cats_returns_active_only_by_default(client):
+    client.post("/cats", json={"name": "Luna", "reference_weight_kg": 4.0})
+    cat_resp = client.post("/cats", json={"name": "Mochi", "reference_weight_kg": 6.0})
+    cat_id = cat_resp.json()["id"]
+    # Deactivate Mochi
+    client.patch(f"/cats/{cat_id}", json={"active": False})
+
+    response = client.get("/cats")
+    assert response.status_code == 200
+    names = [c["name"] for c in response.json()]
+    assert "Luna" in names
+    assert "Mochi" not in names
+
+
+def test_list_cats_include_inactive(client):
+    client.post("/cats", json={"name": "Luna"})
+    cat_resp = client.post("/cats", json={"name": "Mochi"})
+    client.patch(f"/cats/{cat_resp.json()['id']}", json={"active": False})
+
+    response = client.get("/cats?include_inactive=true")
+    assert response.status_code == 200
+    names = [c["name"] for c in response.json()]
+    assert "Luna" in names
+    assert "Mochi" in names
+
+
+def test_list_cats_empty(client):
+    response = client.get("/cats")
+    assert response.status_code == 200
+    assert response.json() == []
+
+
+def test_get_cat(client):
+    create_resp = client.post("/cats", json={"name": "Luna", "reference_weight_kg": 4.0})
+    cat_id = create_resp.json()["id"]
+
+    response = client.get(f"/cats/{cat_id}")
+    assert response.status_code == 200
+    assert response.json()["name"] == "Luna"
+
+
+def test_get_cat_not_found(client):
+    response = client.get("/cats/9999")
+    assert response.status_code == 404
+    assert response.json()["detail"] == "Cat not found"
+
+
+def test_update_cat_name(client):
+    create_resp = client.post("/cats", json={"name": "Luna"})
+    cat_id = create_resp.json()["id"]
+
+    response = client.patch(f"/cats/{cat_id}", json={"name": "Luna II"})
+    assert response.status_code == 200
+    assert response.json()["name"] == "Luna II"
+
+
+def test_update_cat_reference_weight(client):
+    create_resp = client.post("/cats", json={"name": "Luna", "reference_weight_kg": 4.0})
+    cat_id = create_resp.json()["id"]
+
+    response = client.patch(f"/cats/{cat_id}", json={"reference_weight_kg": 4.2})
+    assert response.status_code == 200
+    assert response.json()["reference_weight_kg"] == 4.2
+
+
+def test_deactivate_cat(client):
+    create_resp = client.post("/cats", json={"name": "Luna"})
+    cat_id = create_resp.json()["id"]
+
+    response = client.patch(f"/cats/{cat_id}", json={"active": False})
+    assert response.status_code == 200
+    assert response.json()["active"] is False
+
+
+def test_update_cat_not_found(client):
+    response = client.patch("/cats/9999", json={"name": "Ghost"})
+    assert response.status_code == 404
+    assert response.json()["detail"] == "Cat not found"

--- a/tests/test_api_cleaning_cycles.py
+++ b/tests/test_api_cleaning_cycles.py
@@ -1,0 +1,49 @@
+"""Tests for the /cleaning-cycles API endpoint."""
+from datetime import datetime, timezone
+
+from app.models import CleaningCycle
+
+
+def test_list_cleaning_cycles_empty(client):
+    response = client.get("/cleaning-cycles")
+    assert response.status_code == 200
+    assert response.json() == []
+
+
+def test_list_cleaning_cycles(client, db_session):
+    now = datetime.now(timezone.utc)
+    db_session.add(CleaningCycle(started_at=now))
+    db_session.commit()
+
+    response = client.get("/cleaning-cycles")
+    assert response.status_code == 200
+    cycles = response.json()
+    assert len(cycles) == 1
+    assert cycles[0]["ended_at"] is None
+
+
+def test_list_cleaning_cycles_limit(client, db_session):
+    now = datetime.now(timezone.utc)
+    for _ in range(5):
+        db_session.add(CleaningCycle(started_at=now))
+    db_session.commit()
+
+    response = client.get("/cleaning-cycles?limit=3")
+    assert response.status_code == 200
+    assert len(response.json()) == 3
+
+
+def test_list_cleaning_cycles_returns_most_recent_first(client, db_session):
+    from datetime import timedelta
+    now = datetime.now(timezone.utc)
+    db_session.add(CleaningCycle(started_at=now - timedelta(hours=2)))
+    db_session.add(CleaningCycle(started_at=now))
+    db_session.commit()
+
+    response = client.get("/cleaning-cycles")
+    assert response.status_code == 200
+    cycles = response.json()
+    # Most recent should be first
+    first_time = datetime.fromisoformat(cycles[0]["started_at"])
+    second_time = datetime.fromisoformat(cycles[1]["started_at"])
+    assert first_time > second_time

--- a/tests/test_api_dashboard.py
+++ b/tests/test_api_dashboard.py
@@ -1,0 +1,121 @@
+"""Tests for the /dashboard API endpoint."""
+from datetime import datetime, timezone, timedelta
+
+from app.models import Cat, Visit, CleaningCycle
+
+
+def test_dashboard_empty(client):
+    response = client.get("/dashboard")
+    assert response.status_code == 200
+    data = response.json()
+    assert data["cats"] == []
+    assert data["unidentified_visits_today"] == 0
+    assert data["cleaning_cycles_today"] == 0
+    assert data["poller_healthy"] is False
+    assert "generated_at" in data
+
+
+def test_dashboard_shows_active_cats(client, db_session):
+    db_session.add(Cat(name="Luna", reference_weight_kg=4.0))
+    db_session.add(Cat(name="Mochi", reference_weight_kg=6.0))
+    db_session.commit()
+
+    response = client.get("/dashboard")
+    assert response.status_code == 200
+    data = response.json()
+    names = [c["cat_name"] for c in data["cats"]]
+    assert "Luna" in names
+    assert "Mochi" in names
+
+
+def test_dashboard_excludes_inactive_cats(client, db_session):
+    db_session.add(Cat(name="Luna", active=False))
+    db_session.commit()
+
+    response = client.get("/dashboard")
+    assert response.status_code == 200
+    assert response.json()["cats"] == []
+
+
+def test_dashboard_counts_visits_today(client, db_session):
+    cat = Cat(name="Luna", reference_weight_kg=4.0)
+    db_session.add(cat)
+    db_session.commit()
+
+    now = datetime.now(timezone.utc)
+    today_start = now.replace(hour=0, minute=0, second=0, microsecond=0)
+
+    visit_today = Visit(cat_id=cat.id, started_at=today_start + timedelta(hours=1))
+    visit_yesterday = Visit(
+        cat_id=cat.id,
+        started_at=today_start - timedelta(hours=1),
+    )
+    db_session.add_all([visit_today, visit_yesterday])
+    db_session.commit()
+
+    response = client.get("/dashboard")
+    assert response.status_code == 200
+    cat_data = response.json()["cats"][0]
+    assert cat_data["visits_today"] == 1
+
+
+def test_dashboard_counts_cleaning_cycles_today(client, db_session):
+    now = datetime.now(timezone.utc)
+    today_start = now.replace(hour=0, minute=0, second=0, microsecond=0)
+
+    db_session.add(CleaningCycle(started_at=today_start + timedelta(hours=1)))
+    db_session.add(CleaningCycle(started_at=today_start - timedelta(hours=1)))
+    db_session.commit()
+
+    response = client.get("/dashboard")
+    assert response.status_code == 200
+    assert response.json()["cleaning_cycles_today"] == 1
+
+
+def test_dashboard_counts_unidentified_visits_today(client, db_session):
+    now = datetime.now(timezone.utc)
+    today_start = now.replace(hour=0, minute=0, second=0, microsecond=0)
+
+    # Completed visit with no cat assigned
+    db_session.add(
+        Visit(
+            cat_id=None,
+            started_at=today_start + timedelta(hours=1),
+            ended_at=today_start + timedelta(hours=1, minutes=2),
+        )
+    )
+    db_session.commit()
+
+    response = client.get("/dashboard")
+    assert response.status_code == 200
+    assert response.json()["unidentified_visits_today"] == 1
+
+
+def test_dashboard_time_in_box_today(client, db_session):
+    cat = Cat(name="Luna", reference_weight_kg=4.0)
+    db_session.add(cat)
+    db_session.commit()
+
+    now = datetime.now(timezone.utc)
+    today_start = now.replace(hour=0, minute=0, second=0, microsecond=0)
+
+    db_session.add(
+        Visit(
+            cat_id=cat.id,
+            started_at=today_start + timedelta(hours=1),
+            duration_seconds=120,
+        )
+    )
+    db_session.add(
+        Visit(
+            cat_id=cat.id,
+            started_at=today_start + timedelta(hours=2),
+            duration_seconds=60,
+        )
+    )
+    db_session.commit()
+
+    response = client.get("/dashboard")
+    assert response.status_code == 200
+    cat_data = response.json()["cats"][0]
+    assert cat_data["time_in_box_today_seconds"] == 180

--- a/tests/test_api_visits.py
+++ b/tests/test_api_visits.py
@@ -1,0 +1,165 @@
+"""Tests for the /visits API endpoints."""
+from datetime import datetime, timezone, timedelta
+
+
+def _make_cat(client, name="Luna", weight=4.0):
+    resp = client.post("/cats", json={"name": name, "reference_weight_kg": weight})
+    assert resp.status_code == 200
+    return resp.json()["id"]
+
+
+def _make_visit(client, cat_id, started_at=None, duration_seconds=60, weight_kg=4.1):
+    if started_at is None:
+        started_at = datetime.now(timezone.utc).isoformat()
+    resp = client.post(
+        "/visits",
+        json={
+            "cat_id": cat_id,
+            "started_at": started_at,
+            "duration_seconds": duration_seconds,
+            "weight_kg": weight_kg,
+        },
+    )
+    assert resp.status_code == 201
+    return resp.json()
+
+
+def test_create_visit(client):
+    cat_id = _make_cat(client)
+    visit = _make_visit(client, cat_id)
+
+    assert visit["cat_id"] == cat_id
+    assert visit["weight_kg"] == 4.1
+    assert visit["duration_seconds"] == 60
+    assert visit["identified_by"] == "manual"
+
+
+def test_list_visits(client):
+    cat_id = _make_cat(client)
+    _make_visit(client, cat_id)
+    _make_visit(client, cat_id)
+
+    response = client.get("/visits")
+    assert response.status_code == 200
+    assert len(response.json()) == 2
+
+
+def test_list_visits_filter_by_cat(client):
+    cat1 = _make_cat(client, name="Luna")
+    cat2 = _make_cat(client, name="Mochi", weight=6.0)
+    _make_visit(client, cat1)
+    _make_visit(client, cat2)
+
+    response = client.get(f"/visits?cat_id={cat1}")
+    assert response.status_code == 200
+    visits = response.json()
+    assert len(visits) == 1
+    assert visits[0]["cat_id"] == cat1
+
+
+def test_list_visits_empty(client):
+    response = client.get("/visits")
+    assert response.status_code == 200
+    assert response.json() == []
+
+
+def test_list_visits_limit(client):
+    cat_id = _make_cat(client)
+    for _ in range(5):
+        _make_visit(client, cat_id)
+
+    response = client.get("/visits?limit=3")
+    assert response.status_code == 200
+    assert len(response.json()) == 3
+
+
+def test_get_visit(client):
+    cat_id = _make_cat(client)
+    visit = _make_visit(client, cat_id)
+    visit_id = visit["id"]
+
+    response = client.get(f"/visits/{visit_id}")
+    assert response.status_code == 200
+    assert response.json()["id"] == visit_id
+
+
+def test_get_visit_not_found(client):
+    response = client.get("/visits/9999")
+    assert response.status_code == 404
+    assert response.json()["detail"] == "Visit not found"
+
+
+def test_update_visit_reassigns_cat(client):
+    cat1 = _make_cat(client, name="Luna")
+    cat2 = _make_cat(client, name="Mochi", weight=6.0)
+    visit = _make_visit(client, cat1)
+    visit_id = visit["id"]
+
+    response = client.patch(f"/visits/{visit_id}", json={"cat_id": cat2})
+    assert response.status_code == 200
+    data = response.json()
+    assert data["cat_id"] == cat2
+    assert data["identified_by"] == "manual"
+
+
+def test_update_visit_not_found(client):
+    response = client.patch("/visits/9999", json={"cat_id": 1})
+    assert response.status_code == 404
+
+
+def test_delete_visit(client):
+    cat_id = _make_cat(client)
+    visit = _make_visit(client, cat_id)
+    visit_id = visit["id"]
+
+    response = client.delete(f"/visits/{visit_id}")
+    assert response.status_code == 204
+
+    response = client.get(f"/visits/{visit_id}")
+    assert response.status_code == 404
+
+
+def test_delete_visit_not_found(client):
+    response = client.delete("/visits/9999")
+    assert response.status_code == 404
+
+
+def test_weight_history_returns_data_for_active_cats(client):
+    cat_id = _make_cat(client, name="Luna")
+    now = datetime.now(timezone.utc)
+    _make_visit(client, cat_id, started_at=now.isoformat(), weight_kg=4.1)
+
+    response = client.get("/visits/weight-history")
+    assert response.status_code == 200
+    result = response.json()
+    assert len(result) == 1
+    assert result[0]["cat_name"] == "Luna"
+    assert len(result[0]["data"]) == 1
+    assert result[0]["data"][0]["weight_kg"] == 4.1
+
+
+def test_weight_history_excludes_inactive_cats(client):
+    cat_id = _make_cat(client, name="Luna")
+    _make_visit(client, cat_id)
+    # Deactivate the cat
+    client.patch(f"/cats/{cat_id}", json={"active": False})
+
+    response = client.get("/visits/weight-history")
+    assert response.status_code == 200
+    assert len(response.json()) == 0
+
+
+def test_weight_history_respects_date_range(client):
+    cat_id = _make_cat(client, name="Luna")
+    old_date = (datetime.now(timezone.utc) - timedelta(days=400)).isoformat()
+    recent_date = datetime.now(timezone.utc).isoformat()
+
+    _make_visit(client, cat_id, started_at=old_date)
+    _make_visit(client, cat_id, started_at=recent_date)
+
+    from_date = (datetime.now(timezone.utc) - timedelta(days=30)).isoformat()
+    response = client.get(f"/visits/weight-history?from_date={from_date}")
+    assert response.status_code == 200
+    result = response.json()
+    # Only the recent visit should be included
+    assert len(result[0]["data"]) == 1

--- a/tests/test_health.py
+++ b/tests/test_health.py
@@ -1,0 +1,4 @@
+def test_health_check(client):
+    response = client.get("/health")
+    assert response.status_code == 200
+    assert response.json() == {"status": "ok"}

--- a/tests/test_poller.py
+++ b/tests/test_poller.py
@@ -1,0 +1,245 @@
+"""Tests for LitterboxPoller business logic.
+
+These tests use an in-memory SQLite database to verify that the poller
+correctly creates and updates Visits, CleaningCycles, DeviceSnapshots,
+and SettingsHistory records.
+
+The Tuya cloud connection is mocked out — see the `poller` fixture in conftest.py.
+"""
+from datetime import datetime, timezone, timedelta
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from app.models import Cat, CleaningCycle, DeviceSnapshot, SettingsHistory, Visit
+
+
+NOW = datetime(2024, 6, 1, 12, 0, 0, tzinfo=timezone.utc)
+
+
+# ---------------------------------------------------------------------------
+# _handle_weight_update
+# ---------------------------------------------------------------------------
+
+def test_weight_update_creates_new_visit(poller, db_session):
+    poller._handle_weight_update(4100, NOW)
+
+    visits = db_session.query(Visit).all()
+    assert len(visits) == 1
+    assert visits[0].weight_kg == pytest.approx(4.1)
+    assert visits[0].started_at == NOW
+
+
+def test_weight_update_sets_current_visit(poller):
+    assert poller.current_visit is None
+    poller._handle_weight_update(4100, NOW)
+    assert poller.current_visit is not None
+
+
+def test_weight_update_updates_existing_visit(poller, db_session):
+    # First reading starts a visit
+    poller._handle_weight_update(4100, NOW)
+    # Second reading (different weight) updates the same visit
+    poller._handle_weight_update(4200, NOW + timedelta(seconds=10))
+
+    visits = db_session.query(Visit).all()
+    assert len(visits) == 1
+    assert visits[0].weight_kg == pytest.approx(4.2)
+
+
+def test_weight_update_records_last_weight_at(poller):
+    poller._handle_weight_update(4100, NOW)
+    assert poller.last_weight_at == NOW
+
+
+# ---------------------------------------------------------------------------
+# _handle_visit_complete
+# ---------------------------------------------------------------------------
+
+def test_visit_complete_closes_current_visit(poller, db_session):
+    poller._handle_weight_update(4100, NOW)
+    dps = {"excretion_time_day": 45, "cat_weight": 4100, "excretion_times_day": 1}
+
+    poller._handle_visit_complete(dps, NOW + timedelta(seconds=45))
+
+    visit = db_session.query(Visit).first()
+    assert visit.ended_at is not None
+    assert visit.duration_seconds == 45
+    assert poller.current_visit is None
+
+
+def test_visit_complete_without_prior_visit_creates_one(poller, db_session):
+    """If a completion event arrives without a preceding weight event, a visit is created."""
+    dps = {"excretion_time_day": 30, "cat_weight": 4100, "excretion_times_day": 1}
+
+    poller._handle_visit_complete(dps, NOW)
+
+    visits = db_session.query(Visit).all()
+    assert len(visits) == 1
+    assert visits[0].duration_seconds == 30
+
+
+def test_visit_complete_assigns_cat_when_matching_weight(poller, db_session):
+    cat = Cat(name="Luna", reference_weight_kg=4.0, active=True)
+    db_session.add(cat)
+    db_session.commit()
+
+    poller._handle_weight_update(4050, NOW)
+    dps = {"excretion_time_day": 60, "cat_weight": 4050, "excretion_times_day": 1}
+    poller._handle_visit_complete(dps, NOW + timedelta(seconds=60))
+
+    visit = db_session.query(Visit).first()
+    assert visit.cat_id == cat.id
+    assert visit.identified_by == "auto"
+
+
+def test_visit_complete_leaves_cat_unassigned_for_unknown_weight(poller, db_session):
+    cat = Cat(name="Luna", reference_weight_kg=4.0, active=True)
+    db_session.add(cat)
+    db_session.commit()
+
+    # Weight far outside any cat's threshold
+    poller._handle_weight_update(1000, NOW)
+    dps = {"excretion_time_day": 60, "cat_weight": 1000, "excretion_times_day": 1}
+    poller._handle_visit_complete(dps, NOW + timedelta(seconds=60))
+
+    visit = db_session.query(Visit).first()
+    assert visit.cat_id is None
+
+
+# ---------------------------------------------------------------------------
+# _check_visit_timeout
+# ---------------------------------------------------------------------------
+
+def test_visit_timeout_closes_overdue_visit(poller, db_session):
+    poller._handle_weight_update(4100, NOW)
+    far_future = NOW + timedelta(seconds=400)  # > VISIT_TIMEOUT_SECONDS (300)
+
+    poller._check_visit_timeout(far_future)
+
+    visit = db_session.query(Visit).first()
+    assert visit.ended_at is not None
+    assert poller.current_visit is None
+
+
+def test_visit_timeout_does_not_close_recent_visit(poller, db_session):
+    poller._handle_weight_update(4100, NOW)
+    soon_after = NOW + timedelta(seconds=100)  # < VISIT_TIMEOUT_SECONDS
+
+    poller._check_visit_timeout(soon_after)
+
+    assert poller.current_visit is not None
+
+
+def test_visit_timeout_does_nothing_without_visit(poller):
+    # Should not raise
+    poller._check_visit_timeout(NOW)
+    assert poller.current_visit is None
+
+
+# ---------------------------------------------------------------------------
+# _handle_cleaning_cycle
+# ---------------------------------------------------------------------------
+
+def test_cleaning_cycle_starts_on_true(poller, db_session):
+    poller._handle_cleaning_cycle(True, NOW)
+
+    cycles = db_session.query(CleaningCycle).all()
+    assert len(cycles) == 1
+    assert cycles[0].started_at == NOW
+    assert cycles[0].ended_at is None
+    assert poller.current_cleaning_cycle is not None
+
+
+def test_cleaning_cycle_ends_on_false(poller, db_session):
+    poller._handle_cleaning_cycle(True, NOW)
+    end_time = NOW + timedelta(minutes=5)
+    poller._handle_cleaning_cycle(False, end_time)
+
+    cycle = db_session.query(CleaningCycle).first()
+    assert cycle.ended_at == end_time
+    assert poller.current_cleaning_cycle is None
+
+
+def test_cleaning_cycle_false_without_active_cycle_is_noop(poller, db_session):
+    poller._handle_cleaning_cycle(False, NOW)
+    assert db_session.query(CleaningCycle).count() == 0
+
+
+def test_cleaning_cycle_true_while_already_active_is_noop(poller, db_session):
+    poller._handle_cleaning_cycle(True, NOW)
+    poller._handle_cleaning_cycle(True, NOW + timedelta(seconds=10))
+
+    assert db_session.query(CleaningCycle).count() == 1
+
+
+# ---------------------------------------------------------------------------
+# _record_setting_change
+# ---------------------------------------------------------------------------
+
+def test_record_setting_change_saves_entry(poller, db_session):
+    poller._record_setting_change("deodorization", True, NOW)
+
+    entries = db_session.query(SettingsHistory).all()
+    assert len(entries) == 1
+    assert entries[0].dp == "deodorization"
+    assert entries[0].value == "True"
+    assert entries[0].changed_at == NOW
+
+
+def test_record_multiple_setting_changes(poller, db_session):
+    poller._record_setting_change("child_lock", False, NOW)
+    poller._record_setting_change("child_lock", True, NOW + timedelta(seconds=5))
+
+    assert db_session.query(SettingsHistory).count() == 2
+
+
+# ---------------------------------------------------------------------------
+# _maybe_snapshot
+# ---------------------------------------------------------------------------
+
+def test_maybe_snapshot_saves_on_first_call(poller, db_session):
+    dps = {"cat_weight": 0, "smart_clean": False}
+    poller._maybe_snapshot(dps, NOW)
+
+    snapshots = db_session.query(DeviceSnapshot).all()
+    assert len(snapshots) == 1
+    assert snapshots[0].raw_dps == dps
+
+
+def test_maybe_snapshot_skips_if_interval_not_elapsed(poller, db_session):
+    dps = {"cat_weight": 0}
+    poller._maybe_snapshot(dps, NOW)
+    poller._maybe_snapshot(dps, NOW + timedelta(seconds=10))
+
+    assert db_session.query(DeviceSnapshot).count() == 1
+
+
+def test_maybe_snapshot_saves_after_interval(poller, db_session):
+    from app.poller import SNAPSHOT_INTERVAL_SECONDS
+    dps = {"cat_weight": 0}
+    poller._maybe_snapshot(dps, NOW)
+    poller._maybe_snapshot(dps, NOW + timedelta(seconds=SNAPSHOT_INTERVAL_SECONDS + 1))
+
+    assert db_session.query(DeviceSnapshot).count() == 2
+
+
+# ---------------------------------------------------------------------------
+# _identify_visit_cat (weight update reference weight)
+# ---------------------------------------------------------------------------
+
+def test_identify_visit_cat_updates_reference_weight(poller, db_session):
+    cat = Cat(name="Luna", reference_weight_kg=4.0, active=True)
+    db_session.add(cat)
+    db_session.commit()
+
+    visit = Visit(started_at=NOW, weight_kg=4.2)
+    db_session.add(visit)
+    db_session.commit()
+
+    poller._identify_visit_cat(visit, 4.2)
+    db_session.refresh(cat)
+
+    # Reference weight should have been nudged toward 4.2
+    assert cat.reference_weight_kg != pytest.approx(4.0)
+    assert 4.0 < cat.reference_weight_kg < 4.2


### PR DESCRIPTION
Closes #41

Adds a full pytest test suite covering all API endpoints and poller logic, with in-memory SQLite and mocked Tuya cloud so no credentials are needed. Tests are integrated into deploy.sh and will abort the deploy on failure.

Generated with [Claude Code](https://claude.ai/code)