### PR TITLE
fix: rewrite tools/poller.py to use environment variables

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -24,6 +24,7 @@ pydantic_core==2.41.5
 requests==2.32.5
 SQLAlchemy==2.0.47
 starlette==0.52.1
+python-dotenv>=1.0
 tinytuya==1.17.6
 typing-inspection==0.4.2
 typing_extensions==4.15.0

--- a/tools/.env.example
+++ b/tools/.env.example
@@ -1,0 +1,4 @@
+TUYA_DEV_ID=your_device_id_here
+TUYA_ADDRESS=192.168.x.x
+TUYA_LOCAL_KEY=your_local_key_here
+TUYA_VERSION=3.4

--- a/tools/poller.py
+++ b/tools/poller.py
@@ -1,14 +1,23 @@
-import tinytuya
+import os
 import time
-import json
 
-##Polls the litterbox for output
+import tinytuya
+from dotenv import load_dotenv
+
+load_dotenv()
+
+## Polls the litterbox for output
+
+dev_id = os.environ["TUYA_DEV_ID"]
+address = os.environ["TUYA_ADDRESS"]
+local_key = os.environ["TUYA_LOCAL_KEY"]
+version = float(os.environ.get("TUYA_VERSION", "3.4"))
 
 d = tinytuya.OutletDevice(
-    dev_id="bfb69fa0d9a31595751qfz",
-    address="192.168.68.110",
-    local_key="@4XOjSgO$r/sqZG:",
-    version=3.4
+    dev_id=dev_id,
+    address=address,
+    local_key=local_key,
+    version=version,
 )
 
 d.set_socketPersistent(True)
@@ -21,7 +30,7 @@ KNOWN_DPS = {
     "22": "fault",
 }
 
-print("👀 Watching for changes... (Ctrl+C to stop)\n")
+print("Watching for changes... (Ctrl+C to stop)\n")
 
 previous = {}
 
@@ -37,13 +46,13 @@ while True:
                 previous[k] = v
 
         if changes:
-            print(f"⏰ {time.strftime('%H:%M:%S')} — Changes detected:")
+            print(f"{time.strftime('%H:%M:%S')} — Changes detected:")
             for dp, change in changes.items():
                 label = KNOWN_DPS.get(dp, f"DP {dp} (unknown)")
-                print(f"  [{dp}] {label}: {change['old']} → {change['new']}")
+                print(f"  [{dp}] {label}: {change['old']} -> {change['new']}")
             print()
 
     except Exception as e:
-        print(f"⚠️  Error: {e}")
+        print(f"Error: {e}")
 
     time.sleep(5)


### PR DESCRIPTION
Rewrites `tools/poller.py` to load Tuya device credentials from environment variables via python-dotenv instead of hardcoding them. Adds `tools/.env.example` as a template.

Closes #46.

Generated with [Claude Code](https://claude.ai/code)