### PR TITLE
fix: install requirements before running tests in deploy.sh

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -10,6 +10,10 @@ echo "🐱 Litterbox deploy starting..."
 echo "pulling git data"
 git pull
 
+# Install/update dependencies
+echo "📦 Installing dependencies..."
+pip install -r requirements.txt -q
+
 # Run tests before deploying — abort if any test fails
 echo "🧪 Running tests..."
 python3 -m pytest tests/ -v


### PR DESCRIPTION
Adds `pip install -r requirements.txt` to deploy.sh before running pytest, so all dependencies are always up-to-date before tests run.

Closes #46.

Generated with [Claude Code](https://claude.ai/code)) | [`claude/issue-46-20260307-1633`](https://github.com/selmer/litterbox/tree/claude/issue-46-20260307-1633) | [View job run](https://github.com/selmer/litterbox/actions/runs/22802796377