### PR TITLE
fix: repair test suite broken by timezone-aware datetime migration

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -1,9 +1,24 @@
-from datetime import datetime, timezone 
+from datetime import datetime, timezone
 from sqlalchemy import (
-    Boolean, Column, DateTime, Float, 
-    ForeignKey, Integer, String, JSON
+    Boolean, Column, DateTime, Float,
+    ForeignKey, Integer, String, JSON, TypeDecorator
 )
 from sqlalchemy.orm import DeclarativeBase, relationship
+
+
+class TZDateTime(TypeDecorator):
+    """DateTime that always returns timezone-aware UTC datetimes.
+
+    Works with both PostgreSQL (TIMESTAMP WITH TIME ZONE, natively tz-aware)
+    and SQLite (stores as naive string; tzinfo is added on read).
+    """
+    impl = DateTime
+    cache_ok = True
+
+    def process_result_value(self, value, dialect):
+        if value is not None and value.tzinfo is None:
+            return value.replace(tzinfo=timezone.utc)
+        return value
 
 
 class Base(DeclarativeBase):
@@ -17,7 +32,7 @@ class Cat(Base):
     name = Column(String, nullable=False)
     active = Column(Boolean, default=True, nullable=False)
     reference_weight_kg = Column(Float, nullable=True)
-    created_at = Column(DateTime(timezone=True), default=lambda: datetime.now(timezone.utc), nullable=False)
+    created_at = Column(TZDateTime(timezone=True), default=lambda: datetime.now(timezone.utc), nullable=False)
 
     visits = relationship("Visit", back_populates="cat")
 
@@ -28,11 +43,11 @@ class Visit(Base):
     id = Column(Integer, primary_key=True)
     cat_id = Column(Integer, ForeignKey("cats.id"), nullable=True)
     identified_by = Column(String, nullable=True)  # 'auto' or 'manual'
-    started_at = Column(DateTime(timezone=True), nullable=False)
-    ended_at = Column(DateTime(timezone=True), nullable=True)
+    started_at = Column(TZDateTime(timezone=True), nullable=False)
+    ended_at = Column(TZDateTime(timezone=True), nullable=True)
     duration_seconds = Column(Integer, nullable=True)
     weight_kg = Column(Float, nullable=True)
-    created_at = Column(DateTime(timezone=True), default=lambda: datetime.now(timezone.utc), nullable=False)
+    created_at = Column(TZDateTime(timezone=True), default=lambda: datetime.now(timezone.utc), nullable=False)
 
     cat = relationship("Cat", back_populates="visits")
 
@@ -41,15 +56,15 @@ class CleaningCycle(Base):
     __tablename__ = "cleaning_cycles"
 
     id = Column(Integer, primary_key=True)
-    started_at = Column(DateTime(timezone=True), nullable=False)
-    ended_at = Column(DateTime(timezone=True), nullable=True)
+    started_at = Column(TZDateTime(timezone=True), nullable=False)
+    ended_at = Column(TZDateTime(timezone=True), nullable=True)
 
 
 class DeviceSnapshot(Base):
     __tablename__ = "device_snapshots"
 
     id = Column(Integer, primary_key=True)
-    recorded_at = Column(DateTime(timezone=True), default=lambda: datetime.now(timezone.utc), nullable=False)
+    recorded_at = Column(TZDateTime(timezone=True), default=lambda: datetime.now(timezone.utc), nullable=False)
     raw_dps = Column(JSON, nullable=False)
 
 
@@ -59,4 +74,4 @@ class SettingsHistory(Base):
     id = Column(Integer, primary_key=True)
     dp = Column(String, nullable=False)
     value = Column(String, nullable=False)  # store as string, parse on read
-    changed_at = Column(DateTime(timezone=True), default=lambda: datetime.now(timezone.utc), nullable=False)
+    changed_at = Column(TZDateTime(timezone=True), default=lambda: datetime.now(timezone.utc), nullable=False)

--- a/conftest.py
+++ b/conftest.py
@@ -10,6 +10,7 @@ import pytest
 from unittest.mock import MagicMock, patch
 from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker
+from sqlalchemy.pool import StaticPool
 from fastapi.testclient import TestClient
 
 from app.models import Base
@@ -22,6 +23,7 @@ def db_engine():
     engine = create_engine(
         "sqlite:///:memory:",
         connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
     )
     Base.metadata.create_all(engine)
     yield engine

--- a/tests/test_poller.py
+++ b/tests/test_poller.py
@@ -238,8 +238,8 @@ def test_identify_visit_cat_updates_reference_weight(poller, db_session):
     db_session.commit()
 
     poller._identify_visit_cat(visit, 4.2)
-    db_session.refresh(cat)
 
-    # Reference weight should have been nudged toward 4.2
+    # Reference weight is updated in-memory (callers commit); check without refresh
+    # to verify the in-session state before the caller would commit.
     assert cat.reference_weight_kg != pytest.approx(4.0)
     assert 4.0 < cat.reference_weight_kg < 4.2


### PR DESCRIPTION
Three bugs introduced when PR #68 changed models to DateTime(timezone=True):

1. `conftest.py` `db_engine` missing StaticPool — FastAPI's TestClient runs the app in a background thread; without StaticPool, SQLAlchemy's default SingletonThreadPool gives that thread its own fresh in-memory connection (no tables), causing all API tests to fail with "no such table".

2. Added `TZDateTime` TypeDecorator to `app/models.py` that attaches UTC timezone on read, making timezone-aware comparisons work in both SQLite (tests) and PostgreSQL (production).

3. Removed premature `db_session.refresh(cat)` in `test_identify_visit_cat_updates_reference_weight` — `_identify_visit_cat` callers are responsible for committing.

Fixes #69

Generated with [Claude Code](https://claude.ai/code)