### PR TITLE
feat: implement backend photo storage for CatPhotoUpload

### DIFF
--- a/alembic/versions/f1e2d3c4b5a6_add_photo_path_to_cats.py
+++ b/alembic/versions/f1e2d3c4b5a6_add_photo_path_to_cats.py
@@ -1,0 +1,28 @@
+"""add photo_path to cats
+
+Revision ID: f1e2d3c4b5a6
+Revises: a1b2c3d4e5f6
+Create Date: 2026-03-07 23:00:00.000000
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = 'f1e2d3c4b5a6'
+down_revision: Union[str, Sequence[str], None] = 'a1b2c3d4e5f6'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    op.add_column('cats', sa.Column('photo_path', sa.String(), nullable=True))
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    op.drop_column('cats', 'photo_path')

--- a/app/main.py
+++ b/app/main.py
@@ -75,6 +75,11 @@ def health():
     return {"status": "ok"}
 
 
+# Serve uploaded cat photos
+UPLOADS_DIR = Path(__file__).parent.parent / "uploads"
+UPLOADS_DIR.mkdir(parents=True, exist_ok=True)
+app.mount("/uploads", StaticFiles(directory=UPLOADS_DIR), name="uploads")
+
 # Serve React frontend — must come AFTER API routes
 if FRONTEND_DIST.exists():
     app.mount("/assets", StaticFiles(directory=FRONTEND_DIST / "assets"), name="assets")

--- a/app/models.py
+++ b/app/models.py
@@ -32,6 +32,7 @@ class Cat(Base):
     name = Column(String, nullable=False)
     active = Column(Boolean, default=True, nullable=False)
     reference_weight_kg = Column(Float, nullable=True)
+    photo_path = Column(String, nullable=True)
     created_at = Column(TZDateTime(timezone=True), default=lambda: datetime.now(timezone.utc), nullable=False)
 
     visits = relationship("Visit", back_populates="cat")

--- a/app/routers/cats.py
+++ b/app/routers/cats.py
@@ -1,4 +1,9 @@
+import base64
+import os
+from pathlib import Path
+
 from fastapi import APIRouter, Depends, HTTPException
+from pydantic import BaseModel
 from sqlalchemy.orm import Session
 
 from app.database import get_db
@@ -7,6 +12,20 @@ from app.schemas import CatCreate, CatOut, CatUpdate
 
 router = APIRouter(prefix="/cats", tags=["cats"])
 
+UPLOADS_DIR = Path("uploads/cat_photos")
+
+
+def cat_to_out(cat: Cat) -> CatOut:
+    photo_url = f"/uploads/cat_photos/{cat.id}.jpg" if cat.photo_path else None
+    return CatOut(
+        id=cat.id,
+        name=cat.name,
+        active=cat.active,
+        reference_weight_kg=cat.reference_weight_kg,
+        photo_url=photo_url,
+        created_at=cat.created_at,
+    )
+
 
 @router.post("", response_model=CatOut)
 def create_cat(cat: CatCreate, db: Session = Depends(get_db)):
@@ -14,7 +33,7 @@ def create_cat(cat: CatCreate, db: Session = Depends(get_db)):
     db.add(db_cat)
     db.commit()
     db.refresh(db_cat)
-    return db_cat
+    return cat_to_out(db_cat)
 
 
 @router.get("", response_model=list[CatOut])
@@ -22,7 +41,7 @@ def list_cats(include_inactive: bool = False, db: Session = Depends(get_db)):
     query = db.query(Cat)
     if not include_inactive:
         query = query.filter(Cat.active == True)
-    return query.all()
+    return [cat_to_out(c) for c in query.all()]
 
 
 @router.get("/{cat_id}", response_model=CatOut)
@@ -30,7 +49,7 @@ def get_cat(cat_id: int, db: Session = Depends(get_db)):
     cat = db.query(Cat).filter(Cat.id == cat_id).first()
     if not cat:
         raise HTTPException(status_code=404, detail="Cat not found")
-    return cat
+    return cat_to_out(cat)
 
 
 @router.patch("/{cat_id}", response_model=CatOut)
@@ -42,4 +61,50 @@ def update_cat(cat_id: int, update: CatUpdate, db: Session = Depends(get_db)):
         setattr(cat, field, value)
     db.commit()
     db.refresh(cat)
-    return cat
+    return cat_to_out(cat)
+
+
+class PhotoUpload(BaseModel):
+    photo_data: str  # base64 data URL, e.g. "data:image/jpeg;base64,..."
+
+
+@router.post("/{cat_id}/photo", response_model=CatOut)
+def upload_cat_photo(cat_id: int, body: PhotoUpload, db: Session = Depends(get_db)):
+    cat = db.query(Cat).filter(Cat.id == cat_id).first()
+    if not cat:
+        raise HTTPException(status_code=404, detail="Cat not found")
+
+    # Parse data URL: "data:image/jpeg;base64,<data>"
+    if not body.photo_data.startswith("data:image/"):
+        raise HTTPException(status_code=400, detail="Invalid image data URL")
+    try:
+        header, encoded = body.photo_data.split(",", 1)
+        image_bytes = base64.b64decode(encoded)
+    except Exception:
+        raise HTTPException(status_code=400, detail="Could not decode image data")
+
+    UPLOADS_DIR.mkdir(parents=True, exist_ok=True)
+    photo_path = UPLOADS_DIR / f"{cat_id}.jpg"
+    photo_path.write_bytes(image_bytes)
+
+    cat.photo_path = str(photo_path)
+    db.commit()
+    db.refresh(cat)
+    return cat_to_out(cat)
+
+
+@router.delete("/{cat_id}/photo", response_model=CatOut)
+def delete_cat_photo(cat_id: int, db: Session = Depends(get_db)):
+    cat = db.query(Cat).filter(Cat.id == cat_id).first()
+    if not cat:
+        raise HTTPException(status_code=404, detail="Cat not found")
+
+    if cat.photo_path:
+        photo_file = Path(cat.photo_path)
+        if photo_file.exists():
+            photo_file.unlink()
+        cat.photo_path = None
+        db.commit()
+        db.refresh(cat)
+
+    return cat_to_out(cat)

--- a/app/routers/dashboard.py
+++ b/app/routers/dashboard.py
@@ -79,6 +79,7 @@ def get_dashboard(db: Session = Depends(get_db)):
             cat_id=cat.id,
             cat_name=cat.name,
             reference_weight_kg=cat.reference_weight_kg,
+            photo_url=f"/uploads/cat_photos/{cat.id}.jpg" if cat.photo_path else None,
             visits_today=visits_today,
             time_in_box_today_seconds=time_in_box_today_seconds,
             last_visit_at=last_visit_at,

--- a/app/schemas.py
+++ b/app/schemas.py
@@ -21,6 +21,7 @@ class CatOut(BaseModel):
     name: str
     active: bool
     reference_weight_kg: Optional[float]
+    photo_url: Optional[str] = None
     created_at: datetime
 
     class Config:
@@ -84,6 +85,7 @@ class CatDashboard(BaseModel):
     cat_id: int
     cat_name: str
     reference_weight_kg: Optional[float]
+    photo_url: Optional[str] = None
     visits_today: int
     time_in_box_today_seconds: int
     last_visit_at: Optional[datetime]

--- a/frontend/src/api/client.js
+++ b/frontend/src/api/client.js
@@ -46,6 +46,14 @@ export const getWeightHistory = ({ fromDate, toDate, catId } = {}) =>
     },
   }).then(r => r.data)
 
+// --- Cat photos ---
+
+export const uploadCatPhoto = (catId, photoData) =>
+  api.post(`/cats/${catId}/photo`, { photo_data: photoData }).then(r => r.data)
+
+export const deleteCatPhoto = (catId) =>
+  api.delete(`/cats/${catId}/photo`).then(r => r.data)
+
 // --- Cleaning cycles ---
 
 export const getCleaningCycles = (limit = 50) =>

--- a/frontend/src/components/CatCard.jsx
+++ b/frontend/src/components/CatCard.jsx
@@ -1,25 +1,12 @@
-import { useState, useEffect } from 'react'
+import { useState } from 'react'
 import { formatDistanceToNow } from 'date-fns'
 import CatPhotoUpload from './CatPhotoUpload'
+import { uploadCatPhoto, deleteCatPhoto } from '../api/client'
 
 const PLACEHOLDER_EMOJI = '🐱'
 
 function getCatId(cat) {
   return cat.cat_id || cat.id
-}
-
-function getStoredPhoto(catId) {
-  if (!catId) return null
-  return localStorage.getItem(`cat_photo_${catId}`) || null
-}
-
-function storePhoto(catId, dataUrl) {
-  if (!catId) return
-  if (dataUrl === null) {
-    localStorage.removeItem(`cat_photo_${catId}`)
-  } else {
-    localStorage.setItem(`cat_photo_${catId}`, dataUrl)
-  }
 }
 
 function formatDuration(seconds) {
@@ -30,18 +17,33 @@ function formatDuration(seconds) {
   return `${m}m ${s}s`
 }
 
-export default function CatCard({ cat, isPlaceholder = false, onAddVisit }) {
+export default function CatCard({ cat, isPlaceholder = false, onAddVisit, onPhotoChange }) {
   const catId = getCatId(cat)
-  const [photo, setPhoto] = useState(() => getStoredPhoto(catId))
+  const [photo, setPhoto] = useState(cat.photo_url || null)
   const [showUpload, setShowUpload] = useState(false)
+  const [uploading, setUploading] = useState(false)
 
-  useEffect(() => {
-    setPhoto(getStoredPhoto(catId))
-  }, [catId])
-
-  function handleSavePhoto(dataUrl) {
-    storePhoto(catId, dataUrl)
-    setPhoto(dataUrl)
+  async function handleSavePhoto(dataUrl) {
+    const catIdValue = catId
+    if (dataUrl === null) {
+      try {
+        setUploading(true)
+        const updated = await deleteCatPhoto(catIdValue)
+        setPhoto(updated.photo_url || null)
+        onPhotoChange?.(updated)
+      } finally {
+        setUploading(false)
+      }
+    } else {
+      try {
+        setUploading(true)
+        const updated = await uploadCatPhoto(catIdValue, dataUrl)
+        setPhoto(updated.photo_url || null)
+        onPhotoChange?.(updated)
+      } finally {
+        setUploading(false)
+      }
+    }
     setShowUpload(false)
   }
 
@@ -69,11 +71,11 @@ export default function CatCard({ cat, isPlaceholder = false, onAddVisit }) {
       <div style={{ display: 'flex', gap: 'var(--space-4)', alignItems: 'flex-start', width: '100%' }}>
         <div
           className="cat-card__photo cat-card__photo--clickable"
-          onClick={() => setShowUpload(true)}
+          onClick={() => !uploading && setShowUpload(true)}
           title="Click to change photo"
           role="button"
           tabIndex={0}
-          onKeyDown={e => e.key === 'Enter' && setShowUpload(true)}
+          onKeyDown={e => e.key === 'Enter' && !uploading && setShowUpload(true)}
         >
           {photo ? <img src={photo} alt={cat.cat_name || cat.name} /> : <span>{PLACEHOLDER_EMOJI}</span>}
         </div>


### PR DESCRIPTION
Implements backend photo storage for the CatPhotoUpload component (closes #87).

## Changes
- Add `photo_path` column to Cat model with Alembic migration
- `POST /cats/{cat_id}/photo` accepts a base64 data URL, decodes and saves JPEG to `uploads/cat_photos/{id}.jpg`
- `DELETE /cats/{cat_id}/photo` removes the photo
- `/uploads` mounted as static files so photos are served directly
- `CatOut` and `CatDashboard` schemas now include `photo_url`
- Frontend `CatCard` replaced localStorage with API calls

Generated with [Claude Code](https://claude.ai/code)) | [View job run](https://github.com/selmer/litterbox/actions/runs/22809318740