### PR TITLE
refactor: use short-lived session per poll cycle in LitterboxPoller

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -29,10 +29,8 @@ def run_poller():
 
     logger.info("Poller thread started")
     while True:
-        db = None
         try:
-            db = SessionLocal()
-            poller = LitterboxPoller(db)
+            poller = LitterboxPoller(SessionLocal)
             while True:
                 poller.poll()
                 dashboard_state.last_successful_poll_at = datetime.now(timezone.utc)
@@ -40,9 +38,6 @@ def run_poller():
         except Exception as e:
             logger.exception("Poller crashed, restarting")
             time.sleep(10)
-        finally:
-            if db:
-                db.close()
 
 
 @asynccontextmanager

--- a/app/poller.py
+++ b/app/poller.py
@@ -52,14 +52,21 @@ class LitterboxPoller:
     Stateful poller that tracks the litterbox's DP changes via Tuya cloud API.
     Visit detection is based on weight readings — a visit starts when a weight
     is received.
+
+    A fresh DB session is created and closed on every call to poll() to avoid
+    stale identity-map state and dropped-connection issues with a long-lived
+    session.
     """
 
-    def __init__(self, db_session):
-        self.db = db_session
+    def __init__(self, session_factory):
+        self.session_factory = session_factory
+        self.db = None
         self.cloud: Optional[tinytuya.Cloud] = None
         self.previous_dps: dict = {}
         self.current_visit: Optional[Visit] = None
+        self.current_visit_id: Optional[int] = None
         self.current_cleaning_cycle: Optional[CleaningCycle] = None
+        self.current_cleaning_cycle_id: Optional[int] = None
         self.last_snapshot_at: Optional[datetime] = None
         self.last_weight_at = None
         self._init_cloud()
@@ -81,7 +88,11 @@ class LitterboxPoller:
             self.cloud = None
 
     def poll(self):
-        """Single poll cycle — call this in a loop."""
+        """Single poll cycle — call this in a loop.
+
+        Opens a fresh DB session for the duration of this poll and closes it
+        before returning, ensuring no session state leaks between cycles.
+        """
         if self.cloud is None:
             logger.warning("Cloud not initialized, retrying...")
             self._init_cloud()
@@ -105,12 +116,26 @@ class LitterboxPoller:
             logger.warning("Empty DPs in cloud response")
             return
 
-        now = datetime.now(timezone.utc)
-        self._check_visit_timeout(now)        
-        self._handle_changes(dps, now)
-        self._maybe_snapshot(dps, now)
+        db = self.session_factory()
+        try:
+            self.db = db
+            # Rehydrate any in-progress objects into the new session via their IDs
+            self.current_visit = db.get(Visit, self.current_visit_id) if self.current_visit_id else None
+            self.current_cleaning_cycle = db.get(CleaningCycle, self.current_cleaning_cycle_id) if self.current_cleaning_cycle_id else None
 
-        self.previous_dps = dps
+            now = datetime.now(timezone.utc)
+            self._check_visit_timeout(now)
+            self._handle_changes(dps, now)
+            self._maybe_snapshot(dps, now)
+
+            self.previous_dps = dps
+
+            # Persist IDs so the next poll can reload these objects
+            self.current_visit_id = self.current_visit.id if self.current_visit else None
+            self.current_cleaning_cycle_id = self.current_cleaning_cycle.id if self.current_cleaning_cycle else None
+        finally:
+            self.db = None
+            db.close()
 
     def _handle_changes(self, dps: dict, now: datetime):
         for dp, value in dps.items():

--- a/conftest.py
+++ b/conftest.py
@@ -63,10 +63,13 @@ def poller(db_session):
 
     Uses the same in-memory SQLite db_session so database interactions
     (visits, cleaning cycles, etc.) can be verified after each call.
+    The session factory always returns the shared test session; db is also
+    set directly so internal methods can be called without going through poll().
     """
     mock_cloud = MagicMock()
     mock_cloud.getstatus.return_value = {"success": True, "result": []}
     with patch("app.poller.make_cloud", return_value=mock_cloud):
         from app.poller import LitterboxPoller
-        p = LitterboxPoller(db_session)
+        p = LitterboxPoller(lambda: db_session)
+    p.db = db_session
     yield p


### PR DESCRIPTION
Replace the single long-lived SQLAlchemy session with a session factory. Each `poll()` call opens a fresh session and closes it on exit, eliminating stale identity-map state and dropped-connection risks. In-progress objects spanning multiple polls are tracked by primary-key ID and reloaded each cycle.

Closes #82

Generated with [Claude Code](https://claude.ai/code)