### PR TITLE
feat: add offset pagination to visits endpoint and UI

### DIFF
--- a/app/routers/visits.py
+++ b/app/routers/visits.py
@@ -30,13 +30,17 @@ def create_visit(visit_data: VisitCreate, db: Session = Depends(get_db)):
 @router.get("", response_model=list[VisitOut])
 def list_visits(
     limit: int = 50,
+    offset: int = 0,
     cat_id: Optional[int] = None,
+    unidentified: Optional[bool] = None,
     db: Session = Depends(get_db),
 ):
     query = db.query(Visit).order_by(Visit.started_at.desc())
     if cat_id:
         query = query.filter(Visit.cat_id == cat_id)
-    return query.limit(limit).all()
+    if unidentified:
+        query = query.filter(Visit.cat_id == None)  # noqa: E711
+    return query.offset(offset).limit(limit).all()
 
 
 @router.get("/weight-history", response_model=list[WeightHistory])

--- a/frontend/src/api/client.js
+++ b/frontend/src/api/client.js
@@ -25,8 +25,8 @@ export const updateCat = (id, data) =>
 
 // --- Visits ---
 
-export const getVisits = ({ limit = 50, catId } = {}) =>
-  api.get('/visits', { params: { limit, cat_id: catId } }).then(r => r.data)
+export const getVisits = ({ limit = 50, offset = 0, catId, unidentified } = {}) =>
+  api.get('/visits', { params: { limit, offset, cat_id: catId, unidentified } }).then(r => r.data)
 
 export const createVisit = (data) =>
   api.post('/visits', data).then(r => r.data)

--- a/frontend/src/pages/Visits.jsx
+++ b/frontend/src/pages/Visits.jsx
@@ -3,27 +3,46 @@ import { getVisits, getCats, updateVisit, deleteVisit } from '../api/client'
 import VisitsList from '../components/VisitsList'
 import { useToast } from '../components/Toast'
 
+const PAGE_SIZE = 50
+
 export default function Visits() {
   const [visits, setVisits] = useState([])
   const [cats, setCats] = useState([])
   const [loading, setLoading] = useState(true)
   const [selectedCat, setSelectedCat] = useState(null)
+  const [page, setPage] = useState(0)
+  const [hasMore, setHasMore] = useState(false)
   const [reassigning, setReassigning] = useState(null) // visit being reassigned
   const toast = useToast()
 
   useEffect(() => {
-    async function fetch() {
+    getCats().then(setCats)
+  }, [])
+
+  useEffect(() => {
+    async function fetchVisits() {
       setLoading(true)
       try {
-        const [v, c] = await Promise.all([getVisits({ limit: 100 }), getCats()])
-        setVisits(v)
-        setCats(c)
+        const params = { limit: PAGE_SIZE + 1, offset: page * PAGE_SIZE }
+        if (selectedCat === 'unidentified') {
+          params.unidentified = true
+        } else if (selectedCat !== null) {
+          params.catId = selectedCat
+        }
+        const v = await getVisits(params)
+        setHasMore(v.length > PAGE_SIZE)
+        setVisits(v.slice(0, PAGE_SIZE))
       } finally {
         setLoading(false)
       }
     }
-    fetch()
-  }, [])
+    fetchVisits()
+  }, [selectedCat, page])
+
+  function selectFilter(cat) {
+    setSelectedCat(cat)
+    setPage(0)
+  }
 
   async function handleDelete(visit) {
     try {
@@ -52,10 +71,6 @@ export default function Visits() {
     }
   }
 
-  const filteredVisits = selectedCat
-    ? visits.filter(v => v.cat_id === selectedCat)
-    : visits
-
   if (loading) return <div className="loading">Loading…</div>
 
   return (
@@ -69,7 +84,7 @@ export default function Visits() {
       <div className="flex-center gap-2 mb-6">
         <button
           className={`btn btn-sm ${selectedCat === null ? 'btn-primary' : 'btn-secondary'}`}
-          onClick={() => setSelectedCat(null)}
+          onClick={() => selectFilter(null)}
         >
           All
         </button>
@@ -77,28 +92,46 @@ export default function Visits() {
           <button
             key={cat.id}
             className={`btn btn-sm ${selectedCat === cat.id ? 'btn-primary' : 'btn-secondary'}`}
-            onClick={() => setSelectedCat(cat.id)}
+            onClick={() => selectFilter(cat.id)}
           >
             {cat.name}
           </button>
         ))}
         <button
           className={`btn btn-sm ${selectedCat === 'unidentified' ? 'btn-primary' : 'btn-secondary'}`}
-          onClick={() => setSelectedCat('unidentified')}
+          onClick={() => selectFilter('unidentified')}
         >
           Unidentified
         </button>
       </div>
 
       <VisitsList
-        visits={selectedCat === 'unidentified'
-          ? visits.filter(v => !v.cat_id)
-          : filteredVisits
-        }
+        visits={visits}
         cats={cats}
         onReassign={handleReassign}
         onDelete={handleDelete}
       />
+
+      {/* Pagination controls */}
+      {(page > 0 || hasMore) && (
+        <div className="flex-center gap-2 mt-4">
+          <button
+            className="btn btn-secondary btn-sm"
+            onClick={() => setPage(p => p - 1)}
+            disabled={page === 0}
+          >
+            ← Previous
+          </button>
+          <span className="text-muted" style={{ fontSize: 13 }}>Page {page + 1}</span>
+          <button
+            className="btn btn-secondary btn-sm"
+            onClick={() => setPage(p => p + 1)}
+            disabled={!hasMore}
+          >
+            Next →
+          </button>
+        </div>
+      )}
 
       {/* Reassign modal */}
       {reassigning && (

--- a/frontend/src/pages/Visits.test.jsx
+++ b/frontend/src/pages/Visits.test.jsx
@@ -19,11 +19,23 @@ vi.mock('../components/VisitsList', () => ({
   ),
 }))
 
+const PAGE_SIZE = 50
+
 const mockVisits = [
   { id: 1, cat_id: 10, started_at: '2024-01-01T10:00:00Z', weight_kg: 4.2 },
   { id: 2, cat_id: null, started_at: '2024-01-01T11:00:00Z', weight_kg: null },
 ]
 const mockCats = [{ id: 10, name: 'Mochi', reference_weight_kg: 4.1 }]
+
+// Returns PAGE_SIZE + 1 visits to simulate there being a next page
+function makeLargePage() {
+  return Array.from({ length: PAGE_SIZE + 1 }, (_, i) => ({
+    id: i + 1,
+    cat_id: 10,
+    started_at: '2024-01-01T10:00:00Z',
+    weight_kg: 4.2,
+  }))
+}
 
 function renderVisits() {
   return render(
@@ -119,6 +131,101 @@ describe('Visits page', () => {
       await waitFor(() =>
         expect(screen.queryByText('Reassign visit')).toBeNull()
       )
+    })
+  })
+
+  describe('pagination', () => {
+    it('hides pagination controls when there is only one page', async () => {
+      renderVisits()
+      await waitFor(() => screen.getByText('Visit 1'))
+
+      expect(screen.queryByText('← Previous')).toBeNull()
+      expect(screen.queryByText('Next →')).toBeNull()
+    })
+
+    it('shows Next button when there are more pages', async () => {
+      client.getVisits.mockResolvedValue(makeLargePage())
+      renderVisits()
+
+      await waitFor(() => screen.getByText('Next →'))
+      expect(screen.queryByText('← Previous')).toBeInTheDocument()
+    })
+
+    it('Next button is disabled on the last page', async () => {
+      renderVisits()
+      await waitFor(() => screen.getByText('Visit 1'))
+      // no next page — hasMore is false with only 2 visits
+      expect(screen.queryByText('Next →')).toBeNull()
+    })
+
+    it('advances to the next page when Next is clicked', async () => {
+      const page2Visits = [{ id: 99, cat_id: 10, started_at: '2024-01-02T10:00:00Z', weight_kg: 4.3 }]
+      client.getVisits
+        .mockResolvedValueOnce(makeLargePage())
+        .mockResolvedValueOnce(page2Visits)
+      renderVisits()
+
+      await waitFor(() => screen.getByText('Next →'))
+      fireEvent.click(screen.getByText('Next →'))
+
+      await waitFor(() => expect(client.getVisits).toHaveBeenCalledWith(
+        expect.objectContaining({ offset: PAGE_SIZE })
+      ))
+    })
+
+    it('goes back to the previous page when Previous is clicked', async () => {
+      const page2Visits = [{ id: 99, cat_id: 10, started_at: '2024-01-02T10:00:00Z', weight_kg: 4.3 }]
+      client.getVisits
+        .mockResolvedValueOnce(makeLargePage())
+        .mockResolvedValueOnce(page2Visits)
+        .mockResolvedValueOnce(mockVisits)
+      renderVisits()
+
+      await waitFor(() => screen.getByText('Next →'))
+      fireEvent.click(screen.getByText('Next →'))
+      await waitFor(() => screen.getByText('Visit 99'))
+
+      fireEvent.click(screen.getByText('← Previous'))
+      await waitFor(() => expect(client.getVisits).toHaveBeenLastCalledWith(
+        expect.objectContaining({ offset: 0 })
+      ))
+    })
+
+    it('resets to page 1 when the cat filter changes', async () => {
+      client.getVisits
+        .mockResolvedValueOnce(makeLargePage())  // initial load
+        .mockResolvedValueOnce(makeLargePage())  // after next
+        .mockResolvedValueOnce(mockVisits)       // after filter change
+      renderVisits()
+
+      await waitFor(() => screen.getByText('Next →'))
+      fireEvent.click(screen.getByText('Next →'))
+      await waitFor(() => screen.getByText('Page 2'))
+
+      fireEvent.click(screen.getByText('Mochi'))
+      await waitFor(() => expect(client.getVisits).toHaveBeenCalledWith(
+        expect.objectContaining({ offset: 0, catId: 10 })
+      ))
+    })
+
+    it('passes unidentified=true when Unidentified filter is selected', async () => {
+      renderVisits()
+      await waitFor(() => screen.getByText('Visit 1'))
+
+      fireEvent.click(screen.getByText('Unidentified'))
+      await waitFor(() => expect(client.getVisits).toHaveBeenCalledWith(
+        expect.objectContaining({ unidentified: true, offset: 0 })
+      ))
+    })
+
+    it('passes catId when a cat filter is selected', async () => {
+      renderVisits()
+      await waitFor(() => screen.getByText('Visit 1'))
+
+      fireEvent.click(screen.getByText('Mochi'))
+      await waitFor(() => expect(client.getVisits).toHaveBeenCalledWith(
+        expect.objectContaining({ catId: 10, offset: 0 })
+      ))
     })
   })
 })

--- a/tests/test_api_visits.py
+++ b/tests/test_api_visits.py
@@ -73,6 +73,61 @@ def test_list_visits_limit(client):
     assert len(response.json()) == 3
 
 
+def test_list_visits_offset(client):
+    cat_id = _make_cat(client)
+    # Create 5 visits with distinct timestamps so ordering is deterministic
+    base = datetime(2024, 1, 1, 12, 0, 0, tzinfo=timezone.utc)
+    for i in range(5):
+        _make_visit(client, cat_id, started_at=(base + timedelta(minutes=i)).isoformat())
+
+    # First page
+    page1 = client.get("/visits?limit=3&offset=0").json()
+    assert len(page1) == 3
+
+    # Second page
+    page2 = client.get("/visits?limit=3&offset=3").json()
+    assert len(page2) == 2
+
+    # No overlap
+    ids1 = {v["id"] for v in page1}
+    ids2 = {v["id"] for v in page2}
+    assert ids1.isdisjoint(ids2)
+
+
+def test_list_visits_offset_beyond_end(client):
+    cat_id = _make_cat(client)
+    _make_visit(client, cat_id)
+
+    response = client.get("/visits?limit=10&offset=100")
+    assert response.status_code == 200
+    assert response.json() == []
+
+
+def test_list_visits_unidentified(client):
+    cat_id = _make_cat(client)
+    _make_visit(client, cat_id)
+    # Create a second visit and clear its cat_id to simulate unidentified
+    temp_cat = _make_cat(client, name="Temp")
+    visit = _make_visit(client, temp_cat)
+    client.patch(f"/visits/{visit['id']}", json={"cat_id": None})
+
+    response = client.get("/visits?unidentified=true")
+    assert response.status_code == 200
+    visits = response.json()
+    assert len(visits) == 1
+    assert visits[0]["cat_id"] is None
+
+
+def test_list_visits_unidentified_false_returns_all(client):
+    cat_id = _make_cat(client)
+    _make_visit(client, cat_id)
+    _make_visit(client, cat_id)
+
+    response = client.get("/visits?unidentified=false")
+    assert response.status_code == 200
+    assert len(response.json()) == 2
+
+
 def test_get_visit(client):
     cat_id = _make_cat(client)
     visit = _make_visit(client, cat_id)


### PR DESCRIPTION
Adds offset-based pagination to the `GET /visits` endpoint and implements it in the Visits page.

- `GET /visits` now accepts `offset` and `unidentified` query params
- Visits page uses server-side filtering + prev/next pagination (50 per page)
- Dashboard is unchanged
- Fully unit tested (backend + frontend)

Closes #90

Generated with [Claude Code](https://claude.ai/code)