### PR TITLE
security: replace weak default DB password with generated placeholder

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,13 +1,14 @@
 # PostgreSQL configuration
 # These are used by docker-compose to configure the database container.
-# Override POSTGRES_PASSWORD in any non-development environment.
+# POSTGRES_PASSWORD must be set — there is no default. Generate one with:
+#   openssl rand -hex 32
 POSTGRES_USER=litterbox
-POSTGRES_PASSWORD=changeme
+POSTGRES_PASSWORD=CHANGE_ME_replace_with_output_of_openssl_rand_hex_32
 POSTGRES_DB=litterbox
 
 # Full database URL (required). The app will refuse to start without this.
 # For local development without Docker:
-DATABASE_URL=postgresql://litterbox:changeme@localhost:5432/litterbox
+DATABASE_URL=postgresql://litterbox:CHANGE_ME_replace_with_output_of_openssl_rand_hex_32@localhost:5432/litterbox
 
 # Tuya device configuration
 TUYA_DEVICE_ID=

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,7 +4,7 @@ services:
     ports:
       - "8001:8000"
     environment:
-      - DATABASE_URL=postgresql://${POSTGRES_USER:-litterbox}:${POSTGRES_PASSWORD:-changeme}@db:5432/${POSTGRES_DB:-litterbox}
+      - DATABASE_URL=postgresql://${POSTGRES_USER:-litterbox}:${POSTGRES_PASSWORD}@db:5432/${POSTGRES_DB:-litterbox}
       - TUYA_DEVICE_ID=${TUYA_DEVICE_ID}
       - TUYA_DEVICE_IP=${TUYA_DEVICE_IP}
       - TUYA_API_KEY=${TUYA_API_KEY}
@@ -25,7 +25,7 @@ services:
     image: postgres:16-alpine
     environment:
       - POSTGRES_USER=${POSTGRES_USER:-litterbox}
-      - POSTGRES_PASSWORD=${POSTGRES_PASSWORD:-changeme}
+      - POSTGRES_PASSWORD=${POSTGRES_PASSWORD}
       - POSTGRES_DB=${POSTGRES_DB:-litterbox}
     volumes:
       - postgres_data:/var/lib/postgresql/data


### PR DESCRIPTION
Remove the `:-changeme` default from POSTGRES_PASSWORD in docker-compose.yml so the stack fails loudly if the env var is not set. Update .env.example to use a clearly-unusable placeholder and direct users to generate a strong password with `openssl rand -hex 32`.

Closes #75

Generated with [Claude Code](https://claude.ai/code)